### PR TITLE
Prevent premature "Upgraded" event before all worker nodes are ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensured cluster upgrade completion is only reported when all worker nodes are fully updated and ready.
+
 ## [0.5.1] - 2025-07-08
 
 ### Fixed


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/33902

Previous logic only checked if the `MachineDeployment` and `MachinePool` objects were in a `Ready` condition, which can be true even while nodes are still being replaced.
The new logic is more robust and checks that for both `MachineDeployments` and `MachinePools`, the number of desired replicas matches the number of fully updated, ready, and available replicas.