### PR TITLE
Enhanced MachinePool version checking by connecting to workload clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enhanced MachinePool version checking by connecting to workload clusters to inspect individual node versions.
+- Direct node version validation for MachinePools using `giantswarm.io/machine-pool` labels and workload cluster connectivity.
+- Improved MachineDeployment version checking with individual Machine resource validation through ownership chain traversal.
+- Graceful fallback to basic status checking when workload cluster access fails.
+
 ## [0.5.3] - 2025-07-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Direct node version validation for MachinePools using `giantswarm.io/machine-pool` labels and workload cluster connectivity.
 - Improved MachineDeployment version checking with individual Machine resource validation through ownership chain traversal.
 - Graceful fallback to basic status checking when workload cluster access fails.
+- Vertical Pod Autoscaler (VPA) support for automatic resource scaling based on cluster count and workload (enabled by default).
+- Memory usage optimizations for handling multiple clusters simultaneously.
+- JSON schema validation for VPA configuration in values.yaml.
+
 
 ## [0.5.3] - 2025-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Graceful fallback to basic status checking when workload cluster access fails.
 - Vertical Pod Autoscaler (VPA) support for automatic resource scaling based on cluster count and workload (enabled by default).
 - Memory usage optimizations for handling multiple clusters simultaneously.
-- JSON schema validation for VPA configuration in values.yaml.
+
+### Fixed
+
+- Corrected version matching logic for pinned MachinePools and MachineDeployments that have explicit `spec.template.spec.version` set to allow control plane upgrades while keeping worker nodes at specific versions.
 
 
 ## [0.5.3] - 2025-07-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Corrected version matching logic for pinned MachinePools and MachineDeployments that have explicit `spec.template.spec.version` set to allow control plane upgrades while keeping worker nodes at specific versions.
 
-
 ## [0.5.3] - 2025-07-18
 
 ### Fixed

--- a/helm/cluster-api-events/templates/deployment.yaml
+++ b/helm/cluster-api-events/templates/deployment.yaml
@@ -52,8 +52,8 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 256Mi
           limits:
-            cpu: 200m
-            memory: 128Mi
+            cpu: 500m
+            memory: 512Mi
       terminationGracePeriodSeconds: 10

--- a/helm/cluster-api-events/templates/rbac.yaml
+++ b/helm/cluster-api-events/templates/rbac.yaml
@@ -31,6 +31,7 @@ rules:
   verbs:
     - get
     - list
+    - watch
 - apiGroups:
     - coordination.k8s.io
   resources:

--- a/helm/cluster-api-events/templates/rbac.yaml
+++ b/helm/cluster-api-events/templates/rbac.yaml
@@ -14,12 +14,23 @@ rules:
     - machinedeployments/status
     - machinepools
     - machinepools/status
+    - machines
+    - machines/status
+    - machinesets
+    - machinesets/status
   verbs:
     - get
     - list
     - patch
     - update
     - watch
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+    - list
 - apiGroups:
     - coordination.k8s.io
   resources:

--- a/helm/cluster-api-events/templates/vpa.yaml
+++ b/helm/cluster-api-events/templates/vpa.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.verticalPodAutoscaler.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace" . }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ .Chart.Name }}
+      controlledResources:
+        - cpu
+        - memory
+      minAllowed:
+        cpu: {{ .Values.verticalPodAutoscaler.minAllowed.cpu }}
+        memory: {{ .Values.verticalPodAutoscaler.minAllowed.memory }}
+      maxAllowed:
+        cpu: {{ .Values.verticalPodAutoscaler.maxAllowed.cpu }}
+        memory: {{ .Values.verticalPodAutoscaler.maxAllowed.memory }}
+      mode: Auto
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "resource.default.name"  . }}
+  updatePolicy:
+    updateMode: {{ .Values.verticalPodAutoscaler.updateMode }}
+{{- end }} 

--- a/helm/cluster-api-events/values.schema.json
+++ b/helm/cluster-api-events/values.schema.json
@@ -112,6 +112,40 @@
         },
         "serviceType": {
             "type": "string"
+        },
+        "verticalPodAutoscaler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "updateMode": {
+                    "type": "string",
+                    "enum": ["Off", "Initial", "Auto"]
+                },
+                "minAllowed": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "maxAllowed": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/helm/cluster-api-events/values.yaml
+++ b/helm/cluster-api-events/values.yaml
@@ -32,6 +32,17 @@ securityContext:
     drop:
       - ALL
 
+# Vertical Pod Autoscaler configuration
+verticalPodAutoscaler:
+  enabled: true
+  updateMode: "Auto"
+  minAllowed:
+    cpu: "100m"
+    memory: "256Mi"
+  maxAllowed:
+    cpu: "1000m"
+    memory: "1Gi"
+
 global:
   podSecurityStandards:
     enforced: false

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -66,7 +66,7 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines/status,verbs=get
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets/status,verbs=get
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -62,6 +62,11 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments/status,verbs=get
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools/status,verbs=get
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines/status,verbs=get
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets/status,verbs=get
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
@@ -22,7 +24,7 @@ func isClusterUpgrading(object capiconditions.Getter, condition capi.ConditionTy
 	return capiconditions.IsFalse(object, condition) && capiconditions.GetReason(object, condition) == "RollingUpdateInProgress"
 }
 
-func conditionTimeStampFromReadyState(object capiconditions.Getter, condition capi.ConditionType) (*v1.Time, bool) {
+func conditionTimeStampFromReadyState(object capiconditions.Getter, condition capi.ConditionType) (*metav1.Time, bool) {
 	if isClusterReady(object, condition) {
 		time := capiconditions.GetLastTransitionTime(object, condition)
 		if time != nil {
@@ -34,6 +36,75 @@ func conditionTimeStampFromReadyState(object capiconditions.Getter, condition ca
 
 func isClusterReleaseVersionDifferent(cluster *capi.Cluster) bool {
 	return cluster.Labels[ReleaseVersionLabel] != cluster.Annotations[LastKnownUpgradeVersionAnnotation]
+}
+
+// getWorkloadClusterClient creates a Kubernetes client for the workload cluster
+func getWorkloadClusterClient(ctx context.Context, c client.Client, cluster *capi.Cluster) (kubernetes.Interface, error) {
+	// Get the kubeconfig secret for the workload cluster
+	secretName := fmt.Sprintf("%s-kubeconfig", cluster.Name)
+	secret := &corev1.Secret{}
+
+	if err := c.Get(ctx, types.NamespacedName{
+		Name:      secretName,
+		Namespace: cluster.Namespace,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig secret %s: %w", secretName, err)
+	}
+
+	// Extract kubeconfig data
+	kubeconfigData, ok := secret.Data["value"]
+	if !ok {
+		return nil, fmt.Errorf("kubeconfig secret %s missing 'value' key", secretName)
+	}
+
+	// Create client config from kubeconfig
+	config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create REST config from kubeconfig: %w", err)
+	}
+
+	// Create Kubernetes client
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	return clientset, nil
+}
+
+// checkMachinePoolNodeVersions connects to workload cluster and checks node versions for a MachinePool
+func checkMachinePoolNodeVersions(ctx context.Context, workloadClient kubernetes.Interface, mp *capiexp.MachinePool, expectedVersion string) (bool, []string, error) {
+	// List all nodes in the workload cluster
+	nodes, err := workloadClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("giantswarm.io/machine-pool=%s", mp.Name),
+	})
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to list nodes for MachinePool %s: %w", mp.Name, err)
+	}
+
+	var nodesWithWrongVersion []string
+	allCorrectVersion := true
+
+	for _, node := range nodes.Items {
+		// Skip nodes being drained/cordoned (unschedulable)
+		if node.Spec.Unschedulable {
+			log := log.FromContext(ctx)
+			log.V(1).Info("Skipping unschedulable node in MachinePool version check",
+				"machinePool", mp.Name,
+				"node", node.Name,
+				"nodeVersion", node.Status.NodeInfo.KubeletVersion)
+			continue
+		}
+
+		// Check kubelet version
+		if node.Status.NodeInfo.KubeletVersion != expectedVersion {
+			nodesWithWrongVersion = append(nodesWithWrongVersion,
+				fmt.Sprintf("%s(%s!=%s)", node.Name, node.Status.NodeInfo.KubeletVersion, expectedVersion))
+			allCorrectVersion = false
+		}
+	}
+
+	return allCorrectVersion, nodesWithWrongVersion, nil
 }
 
 // areAllWorkerNodesReady checks if all MachineDeployments and MachinePools are ready
@@ -56,20 +127,94 @@ func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.
 			desiredReplicas = *md.Spec.Replicas
 		}
 
-		rolloutComplete := desiredReplicas == md.Status.UpdatedReplicas &&
+		// For MachineDeployments, check both basic status and individual machine versions
+		basicRolloutComplete := desiredReplicas == md.Status.UpdatedReplicas &&
 			desiredReplicas == md.Status.ReadyReplicas &&
 			desiredReplicas == md.Status.AvailableReplicas
+
+		// Check individual machines for version consistency (MachineDeployments create Machine resources)
+		allMachinesCorrectVersion := true
+		var expectedVersion string
+		if md.Spec.Template.Spec.Version != nil {
+			expectedVersion = *md.Spec.Template.Spec.Version
+		} else {
+			expectedVersion = cluster.Labels[ReleaseVersionLabel]
+		}
+
+		machines := &capi.MachineList{}
+		if err := c.List(ctx, machines, client.InNamespace(cluster.Namespace), client.MatchingLabels{
+			capi.ClusterNameLabel: cluster.Name,
+		}); err != nil {
+			log := log.FromContext(ctx)
+			log.Error(err, "Failed to list machines for MachineDeployment", "machineDeployment", md.Name)
+			allMachinesCorrectVersion = false
+		} else {
+			var machinesWithWrongVersion []string
+
+			// Filter machines belonging to this MachineDeployment
+			for _, machine := range machines.Items {
+				// Check if machine belongs to this MachineDeployment via OwnerReferences
+				belongsToMD := false
+				for _, ownerRef := range machine.OwnerReferences {
+					if ownerRef.Kind == "MachineSet" {
+						// Get the MachineSet to check if it belongs to our MachineDeployment
+						machineSet := &capi.MachineSet{}
+						if err := c.Get(ctx, client.ObjectKey{
+							Namespace: machine.Namespace,
+							Name:      ownerRef.Name,
+						}, machineSet); err == nil {
+							for _, msOwnerRef := range machineSet.OwnerReferences {
+								if msOwnerRef.Kind == "MachineDeployment" && msOwnerRef.Name == md.Name {
+									belongsToMD = true
+									break
+								}
+							}
+						}
+						break
+					}
+				}
+
+				if !belongsToMD {
+					continue
+				}
+
+				// Skip machines being deleted
+				if !machine.DeletionTimestamp.IsZero() {
+					continue
+				}
+
+				// Check machine version
+				if machine.Spec.Version != nil && *machine.Spec.Version != expectedVersion {
+					machinesWithWrongVersion = append(machinesWithWrongVersion,
+						fmt.Sprintf("%s(%s!=%s)", machine.Name, *machine.Spec.Version, expectedVersion))
+					allMachinesCorrectVersion = false
+				}
+			}
+
+			if len(machinesWithWrongVersion) > 0 {
+				log := log.FromContext(ctx)
+				log.V(1).Info("MachineDeployment has machines with incorrect versions",
+					"machineDeployment", md.Name,
+					"expectedVersion", expectedVersion,
+					"machinesWithWrongVersion", machinesWithWrongVersion)
+			}
+		}
+
+		rolloutComplete := basicRolloutComplete && allMachinesCorrectVersion
 
 		log := log.FromContext(ctx)
 		log.V(1).Info("Checking MachineDeployment status",
 			"name", md.Name,
 			"ready", ready,
+			"basicRolloutComplete", basicRolloutComplete,
+			"allMachinesCorrectVersion", allMachinesCorrectVersion,
 			"rolloutComplete", rolloutComplete,
 			"versionMatch", versionMatch,
 			"desiredReplicas", desiredReplicas,
 			"updatedReplicas", md.Status.UpdatedReplicas,
 			"readyReplicas", md.Status.ReadyReplicas,
 			"availableReplicas", md.Status.AvailableReplicas,
+			"expectedVersion", expectedVersion,
 			"mdVersion", md.Labels[ReleaseVersionLabel],
 			"clusterVersion", cluster.Labels[ReleaseVersionLabel],
 			"readyCondition", func() string {
@@ -98,6 +243,21 @@ func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.
 		return false, err
 	}
 
+	// Get workload cluster client for MachinePool node version checking
+	var workloadClient kubernetes.Interface
+	var workloadClientErr error
+
+	// Only try to connect if we have MachinePools to check
+	if len(machinePools.Items) > 0 {
+		workloadClient, workloadClientErr = getWorkloadClusterClient(ctx, c, cluster)
+		if workloadClientErr != nil {
+			log := log.FromContext(ctx)
+			log.V(1).Info("Failed to get workload cluster client, falling back to basic MachinePool checking",
+				"cluster", cluster.Name,
+				"error", workloadClientErr)
+		}
+	}
+
 	var notReadyMPs []string
 	var versionMismatchMPs []string
 	for _, mp := range machinePools.Items {
@@ -109,75 +269,50 @@ func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.
 			desiredReplicas = *mp.Spec.Replicas
 		}
 
-		// For MachinePools, we need to ensure that:
-		// 1. Ready/Available replicas match desired replicas exactly (no extra old nodes)
-		// 2. All referenced nodes are running the expected version FOR THIS MACHINEPOOL
-		//    (not necessarily the cluster version, to support staged upgrades)
-		rolloutComplete := desiredReplicas == mp.Status.ReadyReplicas &&
+		// Check basic readiness first
+		basicRolloutComplete := desiredReplicas == mp.Status.ReadyReplicas &&
 			desiredReplicas == mp.Status.AvailableReplicas
 
-		// Additional check: verify all node references are running the MachinePool's expected version
-		// This supports staged upgrades where MachinePools may be pinned to older versions
+		var expectedVersion string
+		if mp.Spec.Template.Spec.Version != nil {
+			expectedVersion = *mp.Spec.Template.Spec.Version
+		} else {
+			expectedVersion = cluster.Labels[ReleaseVersionLabel]
+		}
+
+		// Try to check actual node versions in workload cluster
 		allNodesCorrectVersion := true
-		if rolloutComplete && mp.Spec.Template.Spec.Version != nil && *mp.Spec.Template.Spec.Version != "" {
-			expectedVersion := *mp.Spec.Template.Spec.Version
+		var nodesWithWrongVersion []string
 
-			// Get all nodes referenced by this MachinePool and check their versions
-			for _, nodeRef := range mp.Status.NodeRefs {
-				node := &corev1.Node{}
-				if err := c.Get(ctx, types.NamespacedName{Name: nodeRef.Name}, node); err != nil {
-					log := log.FromContext(ctx)
-					log.V(1).Info("Failed to get node for version check",
-						"machinePool", mp.Name,
-						"node", nodeRef.Name,
-						"error", err)
-					allNodesCorrectVersion = false
-					break
-				}
-
-				// Skip nodes that are being drained/terminated (SchedulingDisabled)
-				// These nodes are in the process of being removed and shouldn't block upgrade completion
-				if node.Spec.Unschedulable {
-					log := log.FromContext(ctx)
-					log.V(1).Info("Skipping unschedulable node in version check",
-						"machinePool", mp.Name,
-						"node", nodeRef.Name,
-						"nodeVersion", node.Status.NodeInfo.KubeletVersion)
-					continue
-				}
-
-				if node.Status.NodeInfo.KubeletVersion != expectedVersion {
-					log := log.FromContext(ctx)
-					log.V(1).Info("Node version mismatch detected",
-						"machinePool", mp.Name,
-						"node", nodeRef.Name,
-						"nodeVersion", node.Status.NodeInfo.KubeletVersion,
-						"expectedVersion", expectedVersion)
-					allNodesCorrectVersion = false
-					break
-				}
+		if workloadClient != nil && workloadClientErr == nil {
+			var err error
+			allNodesCorrectVersion, nodesWithWrongVersion, err = checkMachinePoolNodeVersions(ctx, workloadClient, &mp, expectedVersion)
+			if err != nil {
+				log := log.FromContext(ctx)
+				log.V(1).Info("Failed to check node versions in workload cluster for MachinePool",
+					"machinePool", mp.Name,
+					"error", err)
+				// Fall back to basic checking if workload cluster access fails
+				allNodesCorrectVersion = true
 			}
 		}
 
-		rolloutComplete = rolloutComplete && allNodesCorrectVersion
+		rolloutComplete := basicRolloutComplete && allNodesCorrectVersion
 
 		log := log.FromContext(ctx)
-		log.V(1).Info("Checking MachinePool status",
+		logLevel := log.V(1)
+
+		logFields := []interface{}{
 			"name", mp.Name,
 			"ready", ready,
+			"basicRolloutComplete", basicRolloutComplete,
 			"rolloutComplete", rolloutComplete,
-			"allNodesCorrectVersion", allNodesCorrectVersion,
 			"versionMatch", versionMatch,
 			"desiredReplicas", desiredReplicas,
 			"readyReplicas", mp.Status.ReadyReplicas,
 			"availableReplicas", mp.Status.AvailableReplicas,
 			"nodeRefsCount", len(mp.Status.NodeRefs),
-			"machinePoolExpectedVersion", func() string {
-				if mp.Spec.Template.Spec.Version != nil {
-					return *mp.Spec.Template.Spec.Version
-				}
-				return ""
-			}(),
+			"expectedVersion", expectedVersion,
 			"mpLabelVersion", mp.Labels[ReleaseVersionLabel],
 			"clusterVersion", cluster.Labels[ReleaseVersionLabel],
 			"readyCondition", func() string {
@@ -185,7 +320,23 @@ func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.
 					return fmt.Sprintf("status=%s,reason=%s", condition.Status, condition.Reason)
 				}
 				return "missing"
-			}())
+			}(),
+		}
+
+		if workloadClient != nil && workloadClientErr == nil {
+			logFields = append(logFields,
+				"allNodesCorrectVersion", allNodesCorrectVersion,
+				"workloadClusterAccess", "successful")
+			if len(nodesWithWrongVersion) > 0 {
+				logFields = append(logFields, "nodesWithWrongVersion", nodesWithWrongVersion)
+			}
+		} else {
+			logFields = append(logFields,
+				"workloadClusterAccess", "failed",
+				"fallbackMode", "basic status checking only")
+		}
+
+		logLevel.Info("Checking MachinePool status", logFields...)
 
 		if !ready || !rolloutComplete {
 			notReadyMPs = append(notReadyMPs, mp.Name)
@@ -203,13 +354,22 @@ func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.
 
 	if !allReady {
 		log := log.FromContext(ctx)
-		log.Info("Worker nodes not all ready",
+		logFields := []interface{}{
 			"totalMachineDeployments", len(machineDeployments.Items),
 			"totalMachinePools", len(machinePools.Items),
 			"notReadyMachineDeployments", notReadyMDs,
 			"notReadyMachinePools", notReadyMPs,
 			"versionMismatchMachineDeployments", versionMismatchMDs,
-			"versionMismatchMachinePools", versionMismatchMPs)
+			"versionMismatchMachinePools", versionMismatchMPs,
+		}
+
+		if workloadClient != nil && workloadClientErr == nil {
+			logFields = append(logFields, "machinePoolVersionChecking", "workload cluster node inspection")
+		} else {
+			logFields = append(logFields, "machinePoolVersionChecking", "basic status only (workload cluster access failed)")
+		}
+
+		log.Info("Worker nodes not all ready", logFields...)
 	}
 
 	return allReady, nil


### PR DESCRIPTION
Fixes a bug I introduced 🤦🏻 and connecting to clusters for nodes is kind of needed for machinepools to verify if the new nodes have the new k8s version. this is needed because machinepools ready state doesn't tell much if the upgrade is finished