### PR TITLE
fix: emit Upgraded event for patch upgrades that don't roll control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Emit `Upgraded` event for patch upgrades that don't roll the control plane. The CP node version check required at least one CP Machine created after `upgrade-start-time`, which never happens for `UpgradingWithoutNodeRoll` upgrades, so the event was never fired and downstream consumers (e.g. Slack `completionEmoji`) could not mark the upgrade complete.
+
 ## [1.3.0] - 2026-03-17
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -412,6 +412,11 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				return ctrl.Result{}, microerror.Mask(err)
 			}
 
+			// Patch upgrades don't roll control plane Machines (release patch typically doesn't bump
+			// the Kubernetes version), so the CP node version check must skip the "rollout has begun"
+			// precondition for them - otherwise the Upgraded event would never fire.
+			isPatchUpgrade := cluster.Annotations[UpgradeTypeAnnotation] == "patch"
+
 			// Check actual control plane node versions in the workload cluster
 			// CAPI controlPlaneUpToDate condition can lag behind actual state,
 			// so we verify kubelet versions on CP nodes directly.
@@ -427,7 +432,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					"error", cpWorkloadClientErr)
 			} else {
 				var checkErr error
-				allCPNodesCorrectVersion, cpNodesWithWrongVersion, checkErr = checkControlPlaneNodeVersions(ctx, r.Client, cpWorkloadClient, cluster, upgradeStartTime)
+				allCPNodesCorrectVersion, cpNodesWithWrongVersion, checkErr = checkControlPlaneNodeVersions(ctx, r.Client, cpWorkloadClient, cluster, upgradeStartTime, isPatchUpgrade)
 				if checkErr != nil {
 					log.V(1).Info("Failed to check CP node versions in workload cluster, will be conservative",
 						"cluster", cluster.Name,
@@ -467,9 +472,6 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// Use atomic claim-and-emit pattern to prevent duplicate events from concurrent reconciles
 			controlPlaneEventSent := cluster.Annotations[EmittedEventsAnnotation] == "UpgradedControlPlane" ||
 				cluster.Annotations[EmittedEventsAnnotation] == "Upgraded"
-
-			// Skip UpgradedControlPlane event for patch upgrades since control plane machines don't roll
-			isPatchUpgrade := cluster.Annotations[UpgradeTypeAnnotation] == "patch"
 
 			// Control plane is done when it's ready, up-to-date, all CP nodes have correct version,
 			// versions match, AND minimum duration has passed.

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -333,9 +333,11 @@ func checkMachineDeploymentNodeVersions(ctx context.Context, mgmtClient client.C
 
 // checkControlPlaneNodeVersions connects to the workload cluster and checks that each control plane
 // Machine's node has a kubelet version matching its Machine's Spec.Version.
-// It also requires that at least one CP Machine was created after upgradeStartTime, to ensure the
-// rollout has actually begun (CAPI conditions and machine specs may not be updated immediately).
-func checkControlPlaneNodeVersions(ctx context.Context, mgmtClient client.Client, workloadClient kubernetes.Interface, cluster *capi.Cluster, upgradeStartTime time.Time) (bool, []string, error) {
+// For non-patch upgrades it also requires that at least one CP Machine was created after
+// upgradeStartTime, to ensure the rollout has actually begun (CAPI conditions and machine specs
+// may not be updated immediately). Patch upgrades skip this precondition because the control
+// plane is not expected to roll, so no new Machine will ever appear.
+func checkControlPlaneNodeVersions(ctx context.Context, mgmtClient client.Client, workloadClient kubernetes.Interface, cluster *capi.Cluster, upgradeStartTime time.Time, isPatchUpgrade bool) (bool, []string, error) {
 	logger := log.FromContext(ctx)
 
 	machines := &capi.MachineList{}
@@ -355,22 +357,25 @@ func checkControlPlaneNodeVersions(ctx context.Context, mgmtClient client.Client
 		return true, nil, nil
 	}
 
-	// Check if at least one Machine was created after the upgrade started.
-	// If not, KCP hasn't started rolling yet — all machines still have the old version.
-	hasNewMachine := false
-	for _, machine := range machines.Items {
-		if machine.CreationTimestamp.Time.After(upgradeStartTime) {
-			hasNewMachine = true
-			break
+	// For minor/major upgrades, require that at least one Machine was created after the upgrade
+	// started. If not, KCP hasn't started rolling yet — all machines still have the old version.
+	// Patch upgrades don't roll the control plane, so this precondition would never be met.
+	if !isPatchUpgrade {
+		hasNewMachine := false
+		for _, machine := range machines.Items {
+			if machine.CreationTimestamp.Time.After(upgradeStartTime) {
+				hasNewMachine = true
+				break
+			}
 		}
-	}
 
-	if !hasNewMachine {
-		logger.Info("No control plane Machine created after upgrade start, rollout has not begun yet",
-			"cluster", cluster.Name,
-			"upgradeStartTime", upgradeStartTime,
-			"machineCount", len(machines.Items))
-		return false, []string{"no new machine since upgrade start"}, nil
+		if !hasNewMachine {
+			logger.Info("No control plane Machine created after upgrade start, rollout has not begun yet",
+				"cluster", cluster.Name,
+				"upgradeStartTime", upgradeStartTime,
+				"machineCount", len(machines.Items))
+			return false, []string{"no new machine since upgrade start"}, nil
+		}
 	}
 
 	logger.V(1).Info("Checking node versions for control plane",


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C37R4Q6JY/p1778074887298169

For `UpgradingWithoutNodeRoll` patch upgrades the CP node version check required at least one CP Machine created after `upgrade-start-time`. That precondition never holds for patches (release patches typically don't bump the Kubernetes version, so KCP doesn't roll), so the `Upgraded` event never fired and downstream consumers (e.g. Slack `completionEmoji`) could not mark the upgrade complete. Skip the precondition for patch upgrades; the kubelet-vs-`Spec.Version` check still runs as the actual verification, and `controlPlaneUpToDate` guards against premature completion in the rare case a patch release does bump K8s.