### PR TITLE
fix: require worker node creation after upgrade start to prevent premature Upgraded event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent premature `Upgraded` event when two releases share the same Kubernetes version (e.g. OS image-only releases on Karpenter-managed pools). Worker node completion now additionally requires each node/Machine to have been (re)created after the upgrade start time, gated by a new `giantswarm.io/upgrade-start-time-source=emit` annotation so controller restarts can't permanently silence the event.
+
 ## [1.3.1] - 2026-05-08
 
 ### Fixed

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -55,6 +55,15 @@ const (
 	UpgradeStartTimeAnnotation   = "giantswarm.io/upgrade-start-time"
 	UpgradeTypeAnnotation        = "giantswarm.io/upgrade-type"
 
+	// UpgradeStartTimeSourceAnnotation records how UpgradeStartTimeAnnotation was set.
+	// "emit" means it was set at the moment we emitted the "Upgrading" event, so it
+	// reliably reflects the actual upgrade start. "synthesized" means it was set as
+	// a fallback (e.g. controller restart) and may not reflect the real start time.
+	// We use this to decide whether the per-node creation-time check is trustworthy.
+	UpgradeStartTimeSourceAnnotation = "giantswarm.io/upgrade-start-time-source"
+	UpgradeStartTimeSourceEmit       = "emit"
+	UpgradeStartTimeSourceSynth      = "synthesized"
+
 	// MinUpgradeDuration is the minimum time that must pass after an upgrade starts
 	// before we consider it complete. This prevents race conditions where CAPI
 	// conditions haven't been updated yet to reflect the upgrade in progress.
@@ -264,6 +273,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			c.Annotations[LastKnownUpgradeVersionAnnotation] = c.Labels[ReleaseVersionLabel]
 			// Reset upgrade start time since we're effectively tracking a new upgrade target
 			c.Annotations[UpgradeStartTimeAnnotation] = time.Now().UTC().Format(time.RFC3339)
+			c.Annotations[UpgradeStartTimeSourceAnnotation] = UpgradeStartTimeSourceEmit
 			// Update upgrade type for the new target
 			c.Annotations[UpgradeTypeAnnotation] = upgradeType.String()
 			// Clear emitted events since the target changed - control plane may need to upgrade further
@@ -322,6 +332,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				c.Annotations[ClusterUpgradingAnnotation] = "true"
 				// Record wall clock time when upgrade starts - used to enforce minimum upgrade duration
 				c.Annotations[UpgradeStartTimeAnnotation] = time.Now().UTC().Format(time.RFC3339)
+				c.Annotations[UpgradeStartTimeSourceAnnotation] = UpgradeStartTimeSourceEmit
 				// Store upgrade type for later use (to skip UpgradedControlPlane for patches)
 				c.Annotations[UpgradeTypeAnnotation] = upgradeType.String()
 				// Set timestamp to current available time to prevent it being reset
@@ -363,10 +374,19 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// CAPI conditions may not be updated immediately when upgrade starts
 			var upgradeStartTime time.Time
 			minDurationPassed := false
+			// startTimeTrustworthy indicates whether upgradeStartTime reliably reflects the
+			// actual moment the upgrade began (i.e. it was stamped during the "Upgrading"
+			// event emit). When false, callers must NOT use it to gate completion via
+			// node CreationTimestamp comparisons, because we'd otherwise wait forever for
+			// nodes that have already been provisioned.
+			startTimeTrustworthy := false
 			if startTimeStr, ok := cluster.Annotations[UpgradeStartTimeAnnotation]; ok {
 				if t, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
 					upgradeStartTime = t
 					minDurationPassed = time.Since(upgradeStartTime) >= MinUpgradeDuration
+					// Trust only when the source annotation explicitly says "emit".
+					// Missing source = pre-fix upgrade in progress -> treat as synthesized.
+					startTimeTrustworthy = cluster.Annotations[UpgradeStartTimeSourceAnnotation] == UpgradeStartTimeSourceEmit
 				}
 			} else {
 				// Annotation missing - this is an upgrade that started before this fix was deployed,
@@ -380,12 +400,15 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					log.Info("Missing upgrade start time annotation, setting it now")
 					if err := updateClusterAnnotations(r.Client, cluster, func(c *capi.Cluster) {
 						c.Annotations[UpgradeStartTimeAnnotation] = time.Now().UTC().Format(time.RFC3339)
+						c.Annotations[UpgradeStartTimeSourceAnnotation] = UpgradeStartTimeSourceSynth
 					}); err != nil {
 						log.Error(err, "Failed to set upgrade start time annotation")
 					}
 					// Don't pass yet, wait for next reconcile
 					minDurationPassed = false
 				}
+				// Fallback path - we don't know the true upgrade start.
+				startTimeTrustworthy = false
 			}
 
 			// In v1beta2, we use Cluster-level conditions which are more reliable than checking individual MachinePool conditions
@@ -402,20 +425,28 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			workerMachinesUpToDate := isClusterReady(cluster, capi.ClusterWorkerMachinesUpToDateCondition)
 			clusterNotRollingOut := !isClusterUpgrading(cluster) // RollingOut condition is False
 
-			// ALWAYS verify actual workload cluster node versions for MachinePools
-			// CAPI conditions can report "up-to-date" based on ASG/Launch Template state,
-			// but the actual nodes in the cluster may not be replaced yet.
-			// This is critical for accurate upgrade completion detection.
-			allWorkerNodesReady, err := areAllWorkerNodesReady(ctx, r.Client, cluster)
-			if err != nil {
-				log.Error(err, "Failed to check worker node ready status")
-				return ctrl.Result{}, microerror.Mask(err)
-			}
-
 			// Patch upgrades don't roll control plane Machines (release patch typically doesn't bump
 			// the Kubernetes version), so the CP node version check must skip the "rollout has begun"
 			// precondition for them - otherwise the Upgraded event would never fire.
 			isPatchUpgrade := cluster.Annotations[UpgradeTypeAnnotation] == "patch"
+
+			// For non-patch upgrades, additionally require all worker nodes to have been
+			// (re)created after upgradeStartTime. This guards against the case where two
+			// releases share the same Kubernetes version (e.g. only OS image changes) and
+			// the kubelet version check is satisfied immediately, causing a premature
+			// "Upgraded" event. We only enforce this when upgradeStartTime is trustworthy;
+			// otherwise we'd wait forever for "newer" nodes after a controller restart.
+			enforceWorkerNodeCreationTime := !isPatchUpgrade && startTimeTrustworthy
+
+			// ALWAYS verify actual workload cluster node versions for MachinePools
+			// CAPI conditions can report "up-to-date" based on ASG/Launch Template state,
+			// but the actual nodes in the cluster may not be replaced yet.
+			// This is critical for accurate upgrade completion detection.
+			allWorkerNodesReady, err := areAllWorkerNodesReady(ctx, r.Client, cluster, upgradeStartTime, enforceWorkerNodeCreationTime)
+			if err != nil {
+				log.Error(err, "Failed to check worker node ready status")
+				return ctrl.Result{}, microerror.Mask(err)
+			}
 
 			// Check actual control plane node versions in the workload cluster
 			// CAPI controlPlaneUpToDate condition can lag behind actual state,
@@ -461,6 +492,8 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				"workerMachinesUpToDate", workerMachinesUpToDate,
 				"clusterNotRollingOut", clusterNotRollingOut,
 				"allWorkerNodesReady", allWorkerNodesReady,
+				"enforceWorkerNodeCreationTime", enforceWorkerNodeCreationTime,
+				"startTimeTrustworthy", startTimeTrustworthy,
 				"minDurationPassed", minDurationPassed,
 				"upgradeStartTime", upgradeStartTime,
 				"timeProgressed", timeProgressed,
@@ -761,6 +794,7 @@ func updateLastKnownTransitionTime(client client.Client, cluster *capi.Cluster, 
 		if !isUpgrading {
 			c.Annotations[LastKnownUpgradeVersionAnnotation] = c.Labels[ReleaseVersionLabel]
 			delete(c.Annotations, UpgradeStartTimeAnnotation)
+			delete(c.Annotations, UpgradeStartTimeSourceAnnotation)
 			delete(c.Annotations, UpgradeTypeAnnotation)
 			// EmittedEventsAnnotation is cleared at the start of the NEXT upgrade, not here
 		}

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -87,8 +87,13 @@ func getWorkloadClusterClient(ctx context.Context, c client.Client, cluster *cap
 	return clientset, nil
 }
 
-// checkMachinePoolNodeVersions connects to workload cluster and checks node versions for a MachinePool
-func checkMachinePoolNodeVersions(ctx context.Context, workloadClient kubernetes.Interface, mp *capi.MachinePool, expectedVersion string) (bool, []string, error) {
+// checkMachinePoolNodeVersions connects to workload cluster and checks node versions for a MachinePool.
+// When enforceCreationTime is true, additionally requires every schedulable node to have a
+// CreationTimestamp strictly after upgradeStartTime. This is necessary for releases that
+// don't bump the Kubernetes version (so the kubelet check alone can't distinguish old
+// nodes from new ones) and for externally-managed pools like Karpenter where CAPI status
+// is unreliable.
+func checkMachinePoolNodeVersions(ctx context.Context, workloadClient kubernetes.Interface, mp *capi.MachinePool, expectedVersion string, upgradeStartTime time.Time, enforceCreationTime bool) (bool, []string, error) {
 	logger := log.FromContext(ctx)
 
 	// Try primary Giant Swarm label first
@@ -206,6 +211,31 @@ func checkMachinePoolNodeVersions(ctx context.Context, workloadClient kubernetes
 					"totalWrongVersionNodes", "10+")
 				break
 			}
+			continue
+		}
+
+		// Creation-time check: catches releases that don't bump kubelet version
+		// (e.g. OS image-only releases) where the kubelet check above is useless.
+		if enforceCreationTime && !node.CreationTimestamp.Time.After(upgradeStartTime) {
+			nodesWithWrongVersion = append(nodesWithWrongVersion,
+				fmt.Sprintf("%s(created %s, before upgrade start %s)",
+					node.Name,
+					node.CreationTimestamp.Time.UTC().Format(time.RFC3339),
+					upgradeStartTime.UTC().Format(time.RFC3339)))
+			allCorrectVersion = false
+
+			logger.Info("Node predates upgrade start - still needs to be rolled",
+				"machinePool", mp.Name,
+				"node", node.Name,
+				"nodeCreatedAt", node.CreationTimestamp.Time,
+				"upgradeStartTime", upgradeStartTime)
+
+			if len(nodesWithWrongVersion) >= 10 {
+				logger.V(1).Info("Truncating wrong version nodes list to prevent memory usage",
+					"machinePool", mp.Name,
+					"totalWrongVersionNodes", "10+")
+				break
+			}
 		}
 	}
 
@@ -229,7 +259,9 @@ func checkMachinePoolNodeVersions(ctx context.Context, workloadClient kubernetes
 // checkMachineDeploymentNodeVersions connects to workload cluster and checks node versions for a MachineDeployment.
 // It lists Machine objects in the management cluster belonging to the MachineDeployment, then for each Machine
 // with a NodeRef, gets the corresponding node from the workload cluster and checks its kubelet version.
-func checkMachineDeploymentNodeVersions(ctx context.Context, mgmtClient client.Client, workloadClient kubernetes.Interface, md *capi.MachineDeployment, expectedVersion string) (bool, []string, error) {
+// When enforceCreationTime is true, additionally requires every Machine to have a CreationTimestamp
+// strictly after upgradeStartTime (catches releases that don't bump the Kubernetes version).
+func checkMachineDeploymentNodeVersions(ctx context.Context, mgmtClient client.Client, workloadClient kubernetes.Interface, md *capi.MachineDeployment, expectedVersion string, upgradeStartTime time.Time, enforceCreationTime bool) (bool, []string, error) {
 	logger := log.FromContext(ctx)
 
 	// List Machine objects in the management cluster belonging to this MachineDeployment
@@ -311,6 +343,32 @@ func checkMachineDeploymentNodeVersions(ctx context.Context, mgmtClient client.C
 				"expectedVersion", expectedVersion)
 
 			// Limit the number of wrong version nodes we track to prevent memory bloat
+			if len(nodesWithWrongVersion) >= 10 {
+				logger.V(1).Info("Truncating wrong version nodes list to prevent memory usage",
+					"machineDeployment", md.Name,
+					"totalWrongVersionNodes", "10+")
+				break
+			}
+			continue
+		}
+
+		// Creation-time check on the Machine (the MachineSet rolls new Machines on upgrade).
+		// Catches releases that don't bump kubelet version (e.g. OS image-only).
+		if enforceCreationTime && !machine.CreationTimestamp.Time.After(upgradeStartTime) {
+			nodesWithWrongVersion = append(nodesWithWrongVersion,
+				fmt.Sprintf("%s(machine created %s, before upgrade start %s)",
+					node.Name,
+					machine.CreationTimestamp.Time.UTC().Format(time.RFC3339),
+					upgradeStartTime.UTC().Format(time.RFC3339)))
+			allCorrectVersion = false
+
+			logger.Info("Machine predates upgrade start - still needs to be rolled",
+				"machineDeployment", md.Name,
+				"machine", machine.Name,
+				"node", node.Name,
+				"machineCreatedAt", machine.CreationTimestamp.Time,
+				"upgradeStartTime", upgradeStartTime)
+
 			if len(nodesWithWrongVersion) >= 10 {
 				logger.V(1).Info("Truncating wrong version nodes list to prevent memory usage",
 					"machineDeployment", md.Name,
@@ -457,8 +515,11 @@ func checkControlPlaneNodeVersions(ctx context.Context, mgmtClient client.Client
 	return allCorrectVersion, nodesWithWrongVersion, nil
 }
 
-// areAllWorkerNodesReady checks if all MachineDeployments and MachinePools are ready
-func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.Cluster) (bool, error) {
+// areAllWorkerNodesReady checks if all MachineDeployments and MachinePools are ready.
+// When enforceCreationTime is true, additionally requires worker nodes/Machines to have been
+// (re)created after upgradeStartTime. Callers must only set this when upgradeStartTime is
+// known to be trustworthy (i.e. stamped at the actual upgrade start, not synthesized).
+func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.Cluster, upgradeStartTime time.Time, enforceCreationTime bool) (bool, error) {
 	machineDeployments := &capi.MachineDeploymentList{}
 	if err := c.List(ctx, machineDeployments, client.InNamespace(cluster.Namespace), client.MatchingLabels{
 		capi.ClusterNameLabel: cluster.Name,
@@ -523,7 +584,7 @@ func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.
 
 		if workloadClient != nil && expectedVersion != "" {
 			var err error
-			allNodesCorrectVersion, nodesWithWrongVersion, err = checkMachineDeploymentNodeVersions(ctx, c, workloadClient, &md, expectedVersion)
+			allNodesCorrectVersion, nodesWithWrongVersion, err = checkMachineDeploymentNodeVersions(ctx, c, workloadClient, &md, expectedVersion, upgradeStartTime, enforceCreationTime)
 			if err != nil {
 				logger := log.FromContext(ctx)
 				logger.V(1).Info("Failed to check node versions in workload cluster for MachineDeployment",
@@ -653,7 +714,7 @@ func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.
 
 		if workloadClient != nil {
 			var err error
-			allNodesCorrectVersion, nodesWithWrongVersion, err = checkMachinePoolNodeVersions(ctx, workloadClient, &mp, expectedVersion)
+			allNodesCorrectVersion, nodesWithWrongVersion, err = checkMachinePoolNodeVersions(ctx, workloadClient, &mp, expectedVersion, upgradeStartTime, enforceCreationTime)
 			if err != nil {
 				log := log.FromContext(ctx)
 				log.V(1).Info("Failed to check node versions in workload cluster for MachinePool",


### PR DESCRIPTION
When two consecutive releases share the same Kubernetes version (e.g. an OS image-only release), the worker node check was satisfied immediately because every node already reported the expected kubelet version. On Karpenter-managed pools — where CAPI status is intentionally bypassed — this caused the `Upgraded` event to fire before old nodes were rolled.

Worker completion now additionally requires each node (MachinePool) or Machine (MachineDeployment) to have been created after `giantswarm.io/upgrade-start-time`. The check is gated by a new `giantswarm.io/upgrade-start-time-source=emit` annotation so synthesized start-times (controller restart, missing annotation) fall back to the previous behavior rather than silencing the event indefinitely. Patch upgrades and unschedulable/draining nodes are unaffected.