### PR TITLE
fix: Emit Upgraded for releases that don't roll workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Emit `Upgraded` for minor/major releases that don't actually roll workers (e.g. chart-only `aws-33.1.4 → aws-33.2.0`). At `Upgrading` time, compare each AWSMachinePool's launch-template `imageLookupFormat` (Flatcar + kubelet) and bootstrap-secret name against existing Machines/Nodes; store the decision in `giantswarm.io/upgrade-rolls-workers` and skip the worker creation-time gate at completion when `false`. Conservative fallback to `true` on any uncertainty.
+
 ## [1.3.2] - 2026-05-15
 
 ### Fixed

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -55,6 +55,16 @@ const (
 	UpgradeStartTimeAnnotation   = "giantswarm.io/upgrade-start-time"
 	UpgradeTypeAnnotation        = "giantswarm.io/upgrade-type"
 
+	// UpgradeRollsWorkersAnnotation records whether the in-flight upgrade is
+	// expected to roll existing worker Nodes. It is set at "Upgrading" emit
+	// time by inspecting each worker MachinePool against the current node
+	// state. When "false", the completion check skips the worker-node
+	// creation-time gate so the "Upgraded" event can fire for releases that
+	// don't actually require nodes to be rolled (e.g. chart-only releases on
+	// external-autoscaler MachinePools that CAPA never auto-rolls). When
+	// missing or "true", the existing creation-time check applies.
+	UpgradeRollsWorkersAnnotation = "giantswarm.io/upgrade-rolls-workers"
+
 	// UpgradeStartTimeSourceAnnotation records how UpgradeStartTimeAnnotation was set.
 	// "emit" means it was set at the moment we emitted the "Upgrading" event, so it
 	// reliably reflects the actual upgrade start. "synthesized" means it was set as
@@ -245,20 +255,18 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		toVersion := cluster.Labels[ReleaseVersionLabel]
 		upgradeType := determineUpgradeType(previousVersion, toVersion)
 
-		var eventReason string
-		switch upgradeType {
-		case UpgradeTypePatch:
-			eventReason = "UpgradingWithoutNodeRoll"
-		case UpgradeTypeMinor, UpgradeTypeMajor:
-			eventReason = "UpgradingWithNodeRoll"
-		default:
-			eventReason = "UpgradingWithNodeRoll"
-		}
+		// Patch upgrades never roll nodes; for minor/major we ask the helper
+		// whether the new release actually changes anything that requires
+		// existing nodes to be replaced.
+		rollsWorkers := upgradeType != UpgradeTypePatch && willUpgradeRollWorkers(ctx, r.Client, cluster)
+
+		eventReason := upgradingEventReason(upgradeType, rollsWorkers)
 
 		log.Info("Cluster upgrade target changed mid-upgrade",
 			"fromVersion", previousVersion,
 			"toVersion", toVersion,
 			"upgradeType", upgradeType,
+			"rollsWorkers", rollsWorkers,
 			"eventReason", eventReason)
 
 		// Message indicates this is a target change, not a new upgrade
@@ -276,6 +284,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			c.Annotations[UpgradeStartTimeSourceAnnotation] = UpgradeStartTimeSourceEmit
 			// Update upgrade type for the new target
 			c.Annotations[UpgradeTypeAnnotation] = upgradeType.String()
+			c.Annotations[UpgradeRollsWorkersAnnotation] = strconv.FormatBool(rollsWorkers)
 			// Clear emitted events since the target changed - control plane may need to upgrade further
 			delete(c.Annotations, EmittedEventsAnnotation)
 		})
@@ -300,24 +309,18 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			toVersion := cluster.Labels[ReleaseVersionLabel]
 			upgradeType := determineUpgradeType(previousVersion, toVersion)
 
-			// Determine event reason based on upgrade type
-			// - UpgradingWithNodeRoll: minor/major upgrades that will replace nodes
-			// - UpgradingWithoutNodeRoll: patch upgrades that won't replace nodes
-			var eventReason string
-			switch upgradeType {
-			case UpgradeTypePatch:
-				eventReason = "UpgradingWithoutNodeRoll"
-			case UpgradeTypeMinor, UpgradeTypeMajor:
-				eventReason = "UpgradingWithNodeRoll"
-			default:
-				// Unknown upgrade type (couldn't parse versions), default to with node roll to be safe
-				eventReason = "UpgradingWithNodeRoll"
-			}
+			// Patch upgrades never roll nodes; for minor/major we ask the helper
+			// whether the new release actually changes anything that requires
+			// existing nodes to be replaced.
+			rollsWorkers := upgradeType != UpgradeTypePatch && willUpgradeRollWorkers(ctx, r.Client, cluster)
+
+			eventReason := upgradingEventReason(upgradeType, rollsWorkers)
 
 			log.Info("Cluster upgrade started",
 				"fromVersion", previousVersion,
 				"toVersion", toVersion,
 				"upgradeType", upgradeType,
+				"rollsWorkers", rollsWorkers,
 				"eventReason", eventReason)
 
 			// Simple event message with version info only
@@ -335,6 +338,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				c.Annotations[UpgradeStartTimeSourceAnnotation] = UpgradeStartTimeSourceEmit
 				// Store upgrade type for later use (to skip UpgradedControlPlane for patches)
 				c.Annotations[UpgradeTypeAnnotation] = upgradeType.String()
+				c.Annotations[UpgradeRollsWorkersAnnotation] = strconv.FormatBool(rollsWorkers)
 				// Set timestamp to current available time to prevent it being reset
 				if readyTransition, ok := conditionTimeStampFromAvailableState(c, capi.AvailableCondition); ok {
 					c.Annotations[LastKnownUpgradeTimestampAnnotation] = readyTransition.UTC().Format(time.RFC3339)
@@ -436,7 +440,11 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// the kubelet version check is satisfied immediately, causing a premature
 			// "Upgraded" event. We only enforce this when upgradeStartTime is trustworthy;
 			// otherwise we'd wait forever for "newer" nodes after a controller restart.
-			enforceWorkerNodeCreationTime := !isPatchUpgrade && startTimeTrustworthy
+			// Additionally skip the check when the release was identified at "Upgrading"
+			// emit time as not actually rolling workers (e.g. chart-only minor release on
+			// external-autoscaler MachinePools that CAPA never auto-rolls).
+			rollsWorkers := cluster.Annotations[UpgradeRollsWorkersAnnotation] != "false"
+			enforceWorkerNodeCreationTime := !isPatchUpgrade && startTimeTrustworthy && rollsWorkers
 
 			// ALWAYS verify actual workload cluster node versions for MachinePools
 			// CAPI conditions can report "up-to-date" based on ASG/Launch Template state,
@@ -493,6 +501,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				"clusterNotRollingOut", clusterNotRollingOut,
 				"allWorkerNodesReady", allWorkerNodesReady,
 				"enforceWorkerNodeCreationTime", enforceWorkerNodeCreationTime,
+				"rollsWorkers", rollsWorkers,
 				"startTimeTrustworthy", startTimeTrustworthy,
 				"minDurationPassed", minDurationPassed,
 				"upgradeStartTime", upgradeStartTime,
@@ -708,6 +717,22 @@ func determineUpgradeType(fromVersion, toVersion string) UpgradeType {
 
 	// Only patch changed
 	return UpgradeTypePatch
+}
+
+// upgradingEventReason picks the customer-facing event reason emitted when an
+// upgrade starts. Patch upgrades are always "without node roll". For
+// minor/major upgrades the rollsWorkers signal — derived from comparing the
+// new release's expected node image against what nodes actually run — refines
+// the reason so we don't promise a node replacement on releases that don't
+// actually need one (e.g. a chart-only minor release).
+func upgradingEventReason(upgradeType UpgradeType, rollsWorkers bool) string {
+	if upgradeType == UpgradeTypePatch {
+		return "UpgradingWithoutNodeRoll"
+	}
+	if rollsWorkers {
+		return "UpgradingWithNodeRoll"
+	}
+	return "UpgradingWithoutNodeRoll"
 }
 
 func updateClusterAnnotations(client client.Client, cluster *capi.Cluster, modifyFunc func(*capi.Cluster)) error {

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -443,7 +443,20 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// Additionally skip the check when the release was identified at "Upgrading"
 			// emit time as not actually rolling workers (e.g. chart-only minor release on
 			// external-autoscaler MachinePools that CAPA never auto-rolls).
-			rollsWorkers := cluster.Annotations[UpgradeRollsWorkersAnnotation] != "false"
+			//
+			// Back-fill: upgrades that started before this annotation existed (controller
+			// upgrade mid-cluster-upgrade) have no value. Compute it once now and persist.
+			rollsAnnotation, rollsAnnotationSet := cluster.Annotations[UpgradeRollsWorkersAnnotation]
+			if !rollsAnnotationSet && !isPatchUpgrade {
+				rolls := willUpgradeRollWorkers(ctx, r.Client, cluster)
+				rollsAnnotation = strconv.FormatBool(rolls)
+				if err := updateClusterAnnotations(r.Client, cluster, func(c *capi.Cluster) {
+					c.Annotations[UpgradeRollsWorkersAnnotation] = rollsAnnotation
+				}); err != nil {
+					log.Error(err, "Failed to back-fill upgrade-rolls-workers annotation; using computed value for this reconcile only")
+				}
+			}
+			rollsWorkers := rollsAnnotation != "false"
 			enforceWorkerNodeCreationTime := !isPatchUpgrade && startTimeTrustworthy && rollsWorkers
 
 			// ALWAYS verify actual workload cluster node versions for MachinePools

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -3,10 +3,14 @@ package controller
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -848,6 +852,218 @@ func areAllWorkerNodesReady(ctx context.Context, c client.Client, cluster *capi.
 	}
 
 	return allReady, nil
+}
+
+// flatcarImageLookupFormatRegex matches imageLookupFormat strings rendered by
+// the giantswarm/cluster-aws Helm chart, e.g.
+//
+//	flatcar-stable-4459.2.1-kube-1.33.6-tooling-1.26.2-gs
+//	flatcar-stable-4459.2.1-kube-1.33.6-tooling-1.26.2-arm64-gs
+//
+// Capture groups: Flatcar OS version, Kubernetes version.
+var flatcarImageLookupFormatRegex = regexp.MustCompile(`^flatcar-[a-z]+-([0-9]+\.[0-9]+\.[0-9]+)-kube-([0-9]+\.[0-9]+\.[0-9]+)-tooling-[0-9]+\.[0-9]+\.[0-9]+(?:-[a-z0-9]+)?-gs$`)
+
+// parseFlatcarImageLookupFormat extracts the Flatcar OS version and Kubernetes
+// version from a chart-rendered imageLookupFormat. Returns ok=false if the
+// string doesn't match the expected pattern.
+func parseFlatcarImageLookupFormat(s string) (flatcarVersion, kubeVersion string, ok bool) {
+	m := flatcarImageLookupFormatRegex.FindStringSubmatch(s)
+	if m == nil {
+		return "", "", false
+	}
+	return m[1], m[2], true
+}
+
+// willUpgradeRollWorkers reports whether the in-flight upgrade is expected to
+// roll existing worker Nodes. It compares the expected Flatcar+kubelet
+// versions (derived from each AWSMachinePool's launch template) against what
+// the observed Nodes actually run. If any worker MachinePool has a node whose
+// kubelet or OS image differs from expected, a roll is required.
+//
+// Returns true (conservative) when state is uncertain:
+//   - workload cluster client unavailable
+//   - non-CAPA infrastructure kind (e.g. KarpenterMachinePool)
+//   - hard-set ami.id on the AWSMachinePool (expected OS not derivable here)
+//   - missing/unparseable imageLookupFormat
+//   - any error fetching nodes or AWSMachinePools
+//
+// This is called once at "Upgrading" emit time so the same decision drives both
+// the customer-facing event reason and the completion-time creation-time check.
+func willUpgradeRollWorkers(ctx context.Context, c client.Client, cluster *capi.Cluster) bool {
+	logger := log.FromContext(ctx)
+
+	machinePools := &capi.MachinePoolList{}
+	if err := c.List(ctx, machinePools, client.InNamespace(cluster.Namespace), client.MatchingLabels{
+		capi.ClusterNameLabel: cluster.Name,
+	}); err != nil {
+		logger.Info("willUpgradeRollWorkers: failed to list MachinePools, assuming node roll", "error", err)
+		return true
+	}
+
+	machineDeployments := &capi.MachineDeploymentList{}
+	if err := c.List(ctx, machineDeployments, client.InNamespace(cluster.Namespace), client.MatchingLabels{
+		capi.ClusterNameLabel: cluster.Name,
+	}); err != nil {
+		logger.Info("willUpgradeRollWorkers: failed to list MachineDeployments, assuming node roll", "error", err)
+		return true
+	}
+
+	// MachineDeployments are rolled by CAPI on any spec change, so we can't
+	// reliably predict "no roll" for them from a snapshot. Be conservative.
+	if len(machineDeployments.Items) > 0 {
+		logger.V(1).Info("willUpgradeRollWorkers: MachineDeployments present, assuming node roll",
+			"machineDeploymentCount", len(machineDeployments.Items))
+		return true
+	}
+
+	// No workers at all: nothing to roll.
+	if len(machinePools.Items) == 0 {
+		logger.V(1).Info("willUpgradeRollWorkers: no worker MachinePools, no node roll required")
+		return false
+	}
+
+	workloadClient, err := getWorkloadClusterClient(ctx, c, cluster)
+	if err != nil {
+		logger.Info("willUpgradeRollWorkers: workload client unavailable, assuming node roll", "error", err)
+		return true
+	}
+
+	inspectedAny := false
+	for _, mp := range machinePools.Items {
+		infraRef := mp.Spec.Template.Spec.InfrastructureRef
+		if infraRef.Kind != "AWSMachinePool" {
+			logger.Info("willUpgradeRollWorkers: non-AWSMachinePool infra, assuming node roll",
+				"machinePool", mp.Name, "infraKind", infraRef.Kind)
+			return true
+		}
+
+		awsmp := &unstructured.Unstructured{}
+		awsmp.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "infrastructure.cluster.x-k8s.io",
+			Version: "v1beta2",
+			Kind:    "AWSMachinePool",
+		})
+		if err := c.Get(ctx, types.NamespacedName{Namespace: mp.Namespace, Name: infraRef.Name}, awsmp); err != nil {
+			logger.Info("willUpgradeRollWorkers: failed to get AWSMachinePool, assuming node roll",
+				"machinePool", mp.Name, "awsmp", infraRef.Name, "error", err)
+			return true
+		}
+
+		// Hard-set AMI: expected OS isn't derivable without an AWS API call.
+		amiID, _, _ := unstructured.NestedString(awsmp.Object, "spec", "awsLaunchTemplate", "ami", "id")
+		if amiID != "" {
+			logger.Info("willUpgradeRollWorkers: AWSMachinePool uses hard-set ami.id, assuming node roll",
+				"machinePool", mp.Name, "amiID", amiID)
+			return true
+		}
+
+		imageLookupFormat, _, _ := unstructured.NestedString(awsmp.Object, "spec", "awsLaunchTemplate", "imageLookupFormat")
+		expectedFlatcar, expectedKube, parseOK := parseFlatcarImageLookupFormat(imageLookupFormat)
+		if !parseOK {
+			logger.Info("willUpgradeRollWorkers: unparseable imageLookupFormat, assuming node roll",
+				"machinePool", mp.Name, "imageLookupFormat", imageLookupFormat)
+			return true
+		}
+
+		// Bootstrap data secret name embeds a content hash; a change means the
+		// chart re-rendered KubeadmConfig (kubelet flags, taints, ignition, etc.)
+		// and CAPA will refresh ASG instances on the resulting user-data change.
+		expectedBootstrap := ""
+		if mp.Spec.Template.Spec.Bootstrap.DataSecretName != nil {
+			expectedBootstrap = *mp.Spec.Template.Spec.Bootstrap.DataSecretName
+		}
+
+		// List Machines owned by this MachinePool so we can verify their
+		// bootstrap secret matches the current spec.
+		machines := &capi.MachineList{}
+		if err := c.List(ctx, machines, client.InNamespace(mp.Namespace), client.MatchingLabels{
+			capi.MachinePoolNameLabel: mp.Name,
+		}); err != nil {
+			logger.Info("willUpgradeRollWorkers: failed to list Machines, assuming node roll",
+				"machinePool", mp.Name, "error", err)
+			return true
+		}
+		if expectedBootstrap != "" {
+			for _, m := range machines.Items {
+				observedBootstrap := ""
+				if m.Spec.Bootstrap.DataSecretName != nil {
+					observedBootstrap = *m.Spec.Bootstrap.DataSecretName
+				}
+				if observedBootstrap != expectedBootstrap {
+					logger.Info("willUpgradeRollWorkers: Machine bootstrap secret differs, node roll required",
+						"machinePool", mp.Name, "machine", m.Name,
+						"observedBootstrap", observedBootstrap, "expectedBootstrap", expectedBootstrap)
+					return true
+				}
+			}
+		}
+
+		nodes, err := listNodesForMachinePool(ctx, workloadClient, mp.Name)
+		if err != nil {
+			logger.Info("willUpgradeRollWorkers: failed to list nodes, assuming node roll",
+				"machinePool", mp.Name, "error", err)
+			return true
+		}
+		if len(nodes) == 0 {
+			logger.V(1).Info("willUpgradeRollWorkers: pool has no nodes, no roll needed for it",
+				"machinePool", mp.Name)
+			continue
+		}
+
+		inspectedAny = true
+		for _, node := range nodes {
+			observedKubelet := node.Status.NodeInfo.KubeletVersion
+			observedOSImage := node.Status.NodeInfo.OSImage
+			kubeletOK := normalizeKubeletVersion(observedKubelet) == "v"+expectedKube
+			osOK := strings.Contains(observedOSImage, expectedFlatcar)
+			if !kubeletOK || !osOK {
+				logger.Info("willUpgradeRollWorkers: node would need to roll",
+					"machinePool", mp.Name, "node", node.Name,
+					"observedKubelet", observedKubelet, "expectedKubelet", "v"+expectedKube,
+					"observedOSImage", observedOSImage, "expectedFlatcar", expectedFlatcar)
+				return true
+			}
+		}
+	}
+
+	if !inspectedAny {
+		logger.V(1).Info("willUpgradeRollWorkers: all worker pools empty, no node roll required")
+		return false
+	}
+
+	logger.Info("willUpgradeRollWorkers: all worker nodes already at expected kubelet+Flatcar versions, no node roll required",
+		"cluster", cluster.Name)
+	return false
+}
+
+// normalizeKubeletVersion prepends "v" if missing so a node's kubeletVersion
+// can be compared against an unprefixed semver parsed from imageLookupFormat.
+func normalizeKubeletVersion(v string) string {
+	if v == "" || strings.HasPrefix(v, "v") {
+		return v
+	}
+	return "v" + v
+}
+
+// listNodesForMachinePool returns all nodes belonging to the given MachinePool.
+// Tries the giantswarm machine-pool label first, then falls back to the
+// Karpenter nodepool label. Schedulable-only filtering is intentionally omitted:
+// we want to inspect every node that exists for the pool.
+func listNodesForMachinePool(ctx context.Context, workloadClient kubernetes.Interface, mpName string) ([]corev1.Node, error) {
+	primary := fmt.Sprintf("giantswarm.io/machine-pool=%s", mpName)
+	nodes, err := workloadClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: primary})
+	if err != nil {
+		return nil, err
+	}
+	if len(nodes.Items) > 0 {
+		return nodes.Items, nil
+	}
+	fallback := fmt.Sprintf("karpenter.sh/nodepool=%s", mpName)
+	nodes, err = workloadClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: fallback})
+	if err != nil {
+		return nil, err
+	}
+	return nodes.Items, nil
 }
 
 // areAnyWorkerNodesUpgrading checks if any MachineDeployments or MachinePools are upgrading

--- a/internal/controller/upgrade_node_roll_test.go
+++ b/internal/controller/upgrade_node_roll_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "testing"
+
+func TestParseFlatcarImageLookupFormat(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantFlatcar   string
+		wantKube      string
+		wantOK        bool
+	}{
+		{
+			name:        "stable channel x86_64 (no arch infix)",
+			input:       "flatcar-stable-4459.2.1-kube-1.33.6-tooling-1.26.2-gs",
+			wantFlatcar: "4459.2.1",
+			wantKube:    "1.33.6",
+			wantOK:      true,
+		},
+		{
+			name:        "stable channel arm64",
+			input:       "flatcar-stable-4459.2.1-kube-1.33.6-tooling-1.26.2-arm64-gs",
+			wantFlatcar: "4459.2.1",
+			wantKube:    "1.33.6",
+			wantOK:      true,
+		},
+		{
+			name:        "lts channel",
+			input:       "flatcar-lts-4081.3.5-kube-1.30.4-tooling-1.25.0-gs",
+			wantFlatcar: "4081.3.5",
+			wantKube:    "1.30.4",
+			wantOK:      true,
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			wantOK: false,
+		},
+		{
+			name:   "missing -gs suffix",
+			input:  "flatcar-stable-4459.2.1-kube-1.33.6-tooling-1.26.2",
+			wantOK: false,
+		},
+		{
+			name:   "missing tooling segment",
+			input:  "flatcar-stable-4459.2.1-kube-1.33.6-gs",
+			wantOK: false,
+		},
+		{
+			name:   "non-numeric flatcar version",
+			input:  "flatcar-stable-foo.bar.baz-kube-1.33.6-tooling-1.26.2-gs",
+			wantOK: false,
+		},
+		{
+			name:   "ubuntu (not flatcar)",
+			input:  "ubuntu-stable-22.04-kube-1.33.6-tooling-1.26.2-gs",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFlatcar, gotKube, gotOK := parseFlatcarImageLookupFormat(tt.input)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if !gotOK {
+				return
+			}
+			if gotFlatcar != tt.wantFlatcar {
+				t.Errorf("flatcarVersion = %q, want %q", gotFlatcar, tt.wantFlatcar)
+			}
+			if gotKube != tt.wantKube {
+				t.Errorf("kubeVersion = %q, want %q", gotKube, tt.wantKube)
+			}
+		})
+	}
+}
+
+func TestNormalizeKubeletVersion(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"v1.33.6", "v1.33.6"},
+		{"1.33.6", "v1.33.6"},
+	}
+	for _, tt := range tests {
+		if got := normalizeKubeletVersion(tt.in); got != tt.want {
+			t.Errorf("normalizeKubeletVersion(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestUpgradingEventReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		upgradeType  UpgradeType
+		rollsWorkers bool
+		want         string
+	}{
+		{"patch with rolls=true ignored", UpgradeTypePatch, true, "UpgradingWithoutNodeRoll"},
+		{"patch with rolls=false", UpgradeTypePatch, false, "UpgradingWithoutNodeRoll"},
+		{"minor with rolls=true", UpgradeTypeMinor, true, "UpgradingWithNodeRoll"},
+		{"minor no-op (rolls=false)", UpgradeTypeMinor, false, "UpgradingWithoutNodeRoll"},
+		{"major with rolls=true", UpgradeTypeMajor, true, "UpgradingWithNodeRoll"},
+		{"major no-op (rolls=false)", UpgradeTypeMajor, false, "UpgradingWithoutNodeRoll"},
+		{"unknown defaults conservatively if rolls=true", UpgradeTypeUnknown, true, "UpgradingWithNodeRoll"},
+		{"unknown with rolls=false", UpgradeTypeUnknown, false, "UpgradingWithoutNodeRoll"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := upgradingEventReason(tt.upgradeType, tt.rollsWorkers); got != tt.want {
+				t.Errorf("upgradingEventReason(%v, %v) = %q, want %q", tt.upgradeType, tt.rollsWorkers, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/upgrade_node_roll_test.go
+++ b/internal/controller/upgrade_node_roll_test.go
@@ -20,31 +20,24 @@ import "testing"
 
 func TestParseFlatcarImageLookupFormat(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         string
-		wantFlatcar   string
-		wantKube      string
-		wantOK        bool
+		name        string
+		input       string
+		wantFlatcar string
+		wantKube    string
+		wantOK      bool
 	}{
 		{
-			name:        "stable channel x86_64 (no arch infix)",
+			name:        "stable x86_64 (no arch infix)",
 			input:       "flatcar-stable-4459.2.1-kube-1.33.6-tooling-1.26.2-gs",
 			wantFlatcar: "4459.2.1",
 			wantKube:    "1.33.6",
 			wantOK:      true,
 		},
 		{
-			name:        "stable channel arm64",
+			name:        "stable arm64",
 			input:       "flatcar-stable-4459.2.1-kube-1.33.6-tooling-1.26.2-arm64-gs",
 			wantFlatcar: "4459.2.1",
 			wantKube:    "1.33.6",
-			wantOK:      true,
-		},
-		{
-			name:        "lts channel",
-			input:       "flatcar-lts-4081.3.5-kube-1.30.4-tooling-1.25.0-gs",
-			wantFlatcar: "4081.3.5",
-			wantKube:    "1.30.4",
 			wantOK:      true,
 		},
 		{
@@ -65,11 +58,6 @@ func TestParseFlatcarImageLookupFormat(t *testing.T) {
 		{
 			name:   "non-numeric flatcar version",
 			input:  "flatcar-stable-foo.bar.baz-kube-1.33.6-tooling-1.26.2-gs",
-			wantOK: false,
-		},
-		{
-			name:   "ubuntu (not flatcar)",
-			input:  "ubuntu-stable-22.04-kube-1.33.6-tooling-1.26.2-gs",
 			wantOK: false,
 		},
 	}


### PR DESCRIPTION
Determine at `Upgrading`-emit time whether the in-flight upgrade will actually roll worker Nodes, by comparing each AWSMachinePool's launch template (`imageLookupFormat` → Flatcar + kubelet) and each owned Machine's bootstrap-secret name against the current MachinePool spec. Store the decision in a new `giantswarm.io/upgrade-rolls-workers` annotation.

When the annotation is `false`, the customer-facing event reason becomes `UpgradingWithoutNodeRoll` and the completion check skips the worker creation-time gate, so `Upgraded` fires for chart-only minor releases (e.g. `aws-33.1.4 → aws-33.2.0`) that would otherwise wait indefinitely on `replicas-managed-by: external-autoscaler` MachinePools.

Conservative fallback to `rolls=true` on any uncertainty (workload client unavailable, non-AWSMachinePool infra, hard-set `ami.id`, unparseable `imageLookupFormat`, MachineDeployments present, list/get errors).

Control-plane completion is unchanged; this annotation only gates the worker check.