### PR TITLE
fix: Decouple Upgrading event reason from worker-roll signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Emit `Upgraded` for minor/major releases that don't actually roll workers (e.g. chart-only `aws-33.1.4 → aws-33.2.0`). At `Upgrading` time, compare each AWSMachinePool's launch-template `imageLookupFormat` (Flatcar + kubelet) and bootstrap-secret name against existing Machines/Nodes; store the decision in `giantswarm.io/upgrade-rolls-workers` and skip the worker creation-time gate at completion when `false`. Conservative fallback to `true` on any uncertainty.
+- Keep `UpgradingWithNodeRoll` as the customer-facing event reason for any non-patch upgrade. The reason describes ALL nodes (control plane + workers) — CAPI begins minor/major upgrades by replacing a control-plane node, so promising "no node roll" would be wrong even when the worker pools are a no-op. The `giantswarm.io/upgrade-rolls-workers` annotation now only gates the worker completion check.
 
 ## [1.3.2] - 2026-05-15
 

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -255,18 +255,12 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		toVersion := cluster.Labels[ReleaseVersionLabel]
 		upgradeType := determineUpgradeType(previousVersion, toVersion)
 
-		// Patch upgrades never roll nodes; for minor/major we ask the helper
-		// whether the new release actually changes anything that requires
-		// existing nodes to be replaced.
-		rollsWorkers := upgradeType != UpgradeTypePatch && willUpgradeRollWorkers(ctx, r.Client, cluster)
-
-		eventReason := upgradingEventReason(upgradeType, rollsWorkers)
+		eventReason := upgradingEventReason(upgradeType)
 
 		log.Info("Cluster upgrade target changed mid-upgrade",
 			"fromVersion", previousVersion,
 			"toVersion", toVersion,
 			"upgradeType", upgradeType,
-			"rollsWorkers", rollsWorkers,
 			"eventReason", eventReason)
 
 		// Message indicates this is a target change, not a new upgrade
@@ -284,7 +278,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			c.Annotations[UpgradeStartTimeSourceAnnotation] = UpgradeStartTimeSourceEmit
 			// Update upgrade type for the new target
 			c.Annotations[UpgradeTypeAnnotation] = upgradeType.String()
-			c.Annotations[UpgradeRollsWorkersAnnotation] = strconv.FormatBool(rollsWorkers)
+			// Clear the per-upgrade worker-roll decision; the back-fill at the
+			// completion check will recompute it against the new target.
+			delete(c.Annotations, UpgradeRollsWorkersAnnotation)
 			// Clear emitted events since the target changed - control plane may need to upgrade further
 			delete(c.Annotations, EmittedEventsAnnotation)
 		})
@@ -309,18 +305,12 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			toVersion := cluster.Labels[ReleaseVersionLabel]
 			upgradeType := determineUpgradeType(previousVersion, toVersion)
 
-			// Patch upgrades never roll nodes; for minor/major we ask the helper
-			// whether the new release actually changes anything that requires
-			// existing nodes to be replaced.
-			rollsWorkers := upgradeType != UpgradeTypePatch && willUpgradeRollWorkers(ctx, r.Client, cluster)
-
-			eventReason := upgradingEventReason(upgradeType, rollsWorkers)
+			eventReason := upgradingEventReason(upgradeType)
 
 			log.Info("Cluster upgrade started",
 				"fromVersion", previousVersion,
 				"toVersion", toVersion,
 				"upgradeType", upgradeType,
-				"rollsWorkers", rollsWorkers,
 				"eventReason", eventReason)
 
 			// Simple event message with version info only
@@ -338,7 +328,10 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				c.Annotations[UpgradeStartTimeSourceAnnotation] = UpgradeStartTimeSourceEmit
 				// Store upgrade type for later use (to skip UpgradedControlPlane for patches)
 				c.Annotations[UpgradeTypeAnnotation] = upgradeType.String()
-				c.Annotations[UpgradeRollsWorkersAnnotation] = strconv.FormatBool(rollsWorkers)
+				// The worker-roll decision is computed lazily at the completion
+				// check (see UpgradeRollsWorkersAnnotation back-fill), so any
+				// stale value from a previous upgrade is cleared here.
+				delete(c.Annotations, UpgradeRollsWorkersAnnotation)
 				// Set timestamp to current available time to prevent it being reset
 				if readyTransition, ok := conditionTimeStampFromAvailableState(c, capi.AvailableCondition); ok {
 					c.Annotations[LastKnownUpgradeTimestampAnnotation] = readyTransition.UTC().Format(time.RFC3339)
@@ -733,19 +726,17 @@ func determineUpgradeType(fromVersion, toVersion string) UpgradeType {
 }
 
 // upgradingEventReason picks the customer-facing event reason emitted when an
-// upgrade starts. Patch upgrades are always "without node roll". For
-// minor/major upgrades the rollsWorkers signal — derived from comparing the
-// new release's expected node image against what nodes actually run — refines
-// the reason so we don't promise a node replacement on releases that don't
-// actually need one (e.g. a chart-only minor release).
-func upgradingEventReason(upgradeType UpgradeType, rollsWorkers bool) string {
+// upgrade starts. The reason covers ALL nodes (control plane + workers):
+// patch upgrades don't roll any nodes; minor/major upgrades virtually always
+// roll the control plane (KubeadmControlPlane spec changes) even when the
+// worker pools are a no-op. The worker-specific decision is tracked separately
+// via the giantswarm.io/upgrade-rolls-workers annotation and only gates the
+// worker completion check, not the customer message.
+func upgradingEventReason(upgradeType UpgradeType) string {
 	if upgradeType == UpgradeTypePatch {
 		return "UpgradingWithoutNodeRoll"
 	}
-	if rollsWorkers {
-		return "UpgradingWithNodeRoll"
-	}
-	return "UpgradingWithoutNodeRoll"
+	return "UpgradingWithNodeRoll"
 }
 
 func updateClusterAnnotations(client client.Client, cluster *capi.Cluster, modifyFunc func(*capi.Cluster)) error {

--- a/internal/controller/upgrade_node_roll_test.go
+++ b/internal/controller/upgrade_node_roll_test.go
@@ -98,24 +98,19 @@ func TestNormalizeKubeletVersion(t *testing.T) {
 
 func TestUpgradingEventReason(t *testing.T) {
 	tests := []struct {
-		name         string
-		upgradeType  UpgradeType
-		rollsWorkers bool
-		want         string
+		name        string
+		upgradeType UpgradeType
+		want        string
 	}{
-		{"patch with rolls=true ignored", UpgradeTypePatch, true, "UpgradingWithoutNodeRoll"},
-		{"patch with rolls=false", UpgradeTypePatch, false, "UpgradingWithoutNodeRoll"},
-		{"minor with rolls=true", UpgradeTypeMinor, true, "UpgradingWithNodeRoll"},
-		{"minor no-op (rolls=false)", UpgradeTypeMinor, false, "UpgradingWithoutNodeRoll"},
-		{"major with rolls=true", UpgradeTypeMajor, true, "UpgradingWithNodeRoll"},
-		{"major no-op (rolls=false)", UpgradeTypeMajor, false, "UpgradingWithoutNodeRoll"},
-		{"unknown defaults conservatively if rolls=true", UpgradeTypeUnknown, true, "UpgradingWithNodeRoll"},
-		{"unknown with rolls=false", UpgradeTypeUnknown, false, "UpgradingWithoutNodeRoll"},
+		{"patch", UpgradeTypePatch, "UpgradingWithoutNodeRoll"},
+		{"minor (CP rolls even if workers don't)", UpgradeTypeMinor, "UpgradingWithNodeRoll"},
+		{"major", UpgradeTypeMajor, "UpgradingWithNodeRoll"},
+		{"unknown defaults to with node roll", UpgradeTypeUnknown, "UpgradingWithNodeRoll"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := upgradingEventReason(tt.upgradeType, tt.rollsWorkers); got != tt.want {
-				t.Errorf("upgradingEventReason(%v, %v) = %q, want %q", tt.upgradeType, tt.rollsWorkers, got, tt.want)
+			if got := upgradingEventReason(tt.upgradeType); got != tt.want {
+				t.Errorf("upgradingEventReason(%v) = %q, want %q", tt.upgradeType, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Follow-up to #110. The customer-facing event reason (`UpgradingWithNodeRoll` vs `UpgradingWithoutNodeRoll`) is about ALL nodes (control plane + workers), not just workers.

CAPI's `KubeadmControlPlane` controller rolls CP machines when `Spec.Version`, `Spec.KubeadmConfigSpec`, or `Spec.MachineTemplate.InfrastructureRef` template materially changes. In practice the `cluster-aws` chart bumps on non-patch releases almost always touch one of those (IAM, IMDS, lifecycle hooks, security groups on `AWSMachineTemplate`), so a CP roll happens — e.g. int03's 33.1.4 → 33.2.0 did roll the control plane on May 19. Promising "no node roll" for a minor/major would therefore be wrong in the common case, even when the worker pools happen to be a no-op for this release.

`upgradingEventReason` is reduced to a semver heuristic: patch → `UpgradingWithoutNodeRoll`, minor/major → `UpgradingWithNodeRoll`. A theoretical chart-only minor release that touches no KCP-relevant field would be a slight inaccuracy (we'd promise a roll that doesn't happen), but we don't have evidence of that being emitted today.

The `giantswarm.io/upgrade-rolls-workers` annotation now exists solely to gate the worker completion check. It is no longer computed eagerly at `Upgrading` emit time; the back-fill at the completion check computes and persists it lazily, which also avoids stale values across mid-upgrade target changes.