### PR TITLE
fix: willUpgradeRollWorkers for empty Karpenter pools and self-heal annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `willUpgradeRollWorkers` was returning conservative `true` even when worker pools were a true no-op: empty `KarpenterMachinePool`s triggered an unconditional non-AWS-infra early return, and the bootstrap-secret comparison always tripped because CAPI doesn't populate `Machine.Spec.Bootstrap.DataSecretName` on MachinePool-owned Machines. Non-AWS pools are now skipped when they have zero replicas (and only assumed-rolling when they actually have nodes), and the unreliable bootstrap-secret check is removed (in-flight rolls are already caught by the `clusterNotRollingOut` guard). The `giantswarm.io/upgrade-rolls-workers` annotation is now persisted only when the decision is `false`, so any previously-cached conservative `true` is recomputed on the next reconcile (self-healing).
+
 ## [1.3.3] - 2026-05-22
 
 ### Fixed

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -433,23 +433,30 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// the kubelet version check is satisfied immediately, causing a premature
 			// "Upgraded" event. We only enforce this when upgradeStartTime is trustworthy;
 			// otherwise we'd wait forever for "newer" nodes after a controller restart.
-			// Additionally skip the check when the release was identified at "Upgrading"
-			// emit time as not actually rolling workers (e.g. chart-only minor release on
-			// external-autoscaler MachinePools that CAPA never auto-rolls).
+			// Additionally skip the check when the release was identified as not actually
+			// rolling workers (e.g. chart-only minor release on external-autoscaler
+			// MachinePools that CAPA never auto-rolls).
 			//
-			// Back-fill: upgrades that started before this annotation existed (controller
-			// upgrade mid-cluster-upgrade) have no value. Compute it once now and persist.
-			rollsAnnotation, rollsAnnotationSet := cluster.Annotations[UpgradeRollsWorkersAnnotation]
-			if !rollsAnnotationSet && !isPatchUpgrade {
-				rolls := willUpgradeRollWorkers(ctx, r.Client, cluster)
-				rollsAnnotation = strconv.FormatBool(rolls)
-				if err := updateClusterAnnotations(r.Client, cluster, func(c *capi.Cluster) {
-					c.Annotations[UpgradeRollsWorkersAnnotation] = rollsAnnotation
-				}); err != nil {
-					log.Error(err, "Failed to back-fill upgrade-rolls-workers annotation; using computed value for this reconcile only")
+			// We only persist the annotation when the computed value is "false" — that's
+			// the definitive "no roll needed" decision and it's the only state we want to
+			// cache to avoid recomputing every reconcile. Missing or "true" → recompute,
+			// which makes the helper self-healing: any prior conservative "true" from an
+			// earlier buggy code path is automatically reconsidered next reconcile.
+			rollsWorkers := true
+			if !isPatchUpgrade {
+				if cluster.Annotations[UpgradeRollsWorkersAnnotation] == "false" {
+					rollsWorkers = false
+				} else {
+					rollsWorkers = willUpgradeRollWorkers(ctx, r.Client, cluster)
+					if !rollsWorkers {
+						if err := updateClusterAnnotations(r.Client, cluster, func(c *capi.Cluster) {
+							c.Annotations[UpgradeRollsWorkersAnnotation] = "false"
+						}); err != nil {
+							log.Error(err, "Failed to persist upgrade-rolls-workers=false; will recompute next reconcile")
+						}
+					}
 				}
 			}
-			rollsWorkers := rollsAnnotation != "false"
 			enforceWorkerNodeCreationTime := !isPatchUpgrade && startTimeTrustworthy && rollsWorkers
 
 			// ALWAYS verify actual workload cluster node versions for MachinePools

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -931,9 +931,23 @@ func willUpgradeRollWorkers(ctx context.Context, c client.Client, cluster *capi.
 	inspectedAny := false
 	for _, mp := range machinePools.Items {
 		infraRef := mp.Spec.Template.Spec.InfrastructureRef
+
+		// Non-AWSMachinePool infra (e.g. KarpenterMachinePool) doesn't have a
+		// CAPA launch template we can introspect uniformly. If the pool has no
+		// nodes, there's nothing to roll for it — skip and check other pools.
+		// If it does have nodes, fall back conservatively.
 		if infraRef.Kind != "AWSMachinePool" {
-			logger.Info("willUpgradeRollWorkers: non-AWSMachinePool infra, assuming node roll",
-				"machinePool", mp.Name, "infraKind", infraRef.Kind)
+			poolReplicas := int32(0)
+			if mp.Status.Replicas != nil {
+				poolReplicas = *mp.Status.Replicas
+			}
+			if poolReplicas == 0 {
+				logger.V(1).Info("willUpgradeRollWorkers: non-AWSMachinePool pool is empty, skipping",
+					"machinePool", mp.Name, "infraKind", infraRef.Kind)
+				continue
+			}
+			logger.Info("willUpgradeRollWorkers: non-AWSMachinePool pool has nodes, assuming node roll",
+				"machinePool", mp.Name, "infraKind", infraRef.Kind, "replicas", poolReplicas)
 			return true
 		}
 
@@ -965,38 +979,13 @@ func willUpgradeRollWorkers(ctx context.Context, c client.Client, cluster *capi.
 			return true
 		}
 
-		// Bootstrap data secret name embeds a content hash; a change means the
-		// chart re-rendered KubeadmConfig (kubelet flags, taints, ignition, etc.)
-		// and CAPA will refresh ASG instances on the resulting user-data change.
-		expectedBootstrap := ""
-		if mp.Spec.Template.Spec.Bootstrap.DataSecretName != nil {
-			expectedBootstrap = *mp.Spec.Template.Spec.Bootstrap.DataSecretName
-		}
-
-		// List Machines owned by this MachinePool so we can verify their
-		// bootstrap secret matches the current spec.
-		machines := &capi.MachineList{}
-		if err := c.List(ctx, machines, client.InNamespace(mp.Namespace), client.MatchingLabels{
-			capi.MachinePoolNameLabel: mp.Name,
-		}); err != nil {
-			logger.Info("willUpgradeRollWorkers: failed to list Machines, assuming node roll",
-				"machinePool", mp.Name, "error", err)
-			return true
-		}
-		if expectedBootstrap != "" {
-			for _, m := range machines.Items {
-				observedBootstrap := ""
-				if m.Spec.Bootstrap.DataSecretName != nil {
-					observedBootstrap = *m.Spec.Bootstrap.DataSecretName
-				}
-				if observedBootstrap != expectedBootstrap {
-					logger.Info("willUpgradeRollWorkers: Machine bootstrap secret differs, node roll required",
-						"machinePool", mp.Name, "machine", m.Name,
-						"observedBootstrap", observedBootstrap, "expectedBootstrap", expectedBootstrap)
-					return true
-				}
-			}
-		}
+		// Note: we intentionally do not compare Machine.Spec.Bootstrap.DataSecretName
+		// here. For MachinePool-owned Machines CAPI doesn't populate that field
+		// per-Machine (the secret reference lives on the MachinePool spec only),
+		// so the comparison would always trigger a false positive.
+		// If a chart bump changes the user-data hash, CAPA refreshes the ASG
+		// instances; the in-flight roll is already caught by the cluster's
+		// RollingOut condition (clusterNotRollingOut guard in the completion check).
 
 		nodes, err := listNodesForMachinePool(ctx, workloadClient, mp.Name)
 		if err != nil {


### PR DESCRIPTION
Follow-up to #110 / #111. Spotted on int03 after v1.3.3 rolled out: the helper persisted `rolls-workers=true` even though it should have been `false`.

## Bugs

1. **Empty `KarpenterMachinePool` triggered conservative `true`**. The non-AWSMachinePool early return forced `true` regardless of whether the Karpenter pool had any nodes. For `int03-spotkarp` (0 replicas) this meant we never got to evaluate the AWS pools at all.
2. **Bootstrap-secret comparison was always tripping**. CAPI does not populate `Machine.Spec.Bootstrap.DataSecretName` on MachinePool-owned Machines (the secret reference lives on the MachinePool spec only). The observed value was always `""`, so the comparison against the MachinePool's expected secret name always returned `true`.

## Fixes

- Non-AWSMachinePool pools (Karpenter) are skipped when `Status.Replicas == 0`; only pools with actual nodes still force the conservative `true`.
- The unreliable bootstrap-secret comparison is removed. In-flight rolls triggered by chart-induced user-data changes are still caught by the existing `clusterNotRollingOut` guard in the completion check.
- The `giantswarm.io/upgrade-rolls-workers` annotation is now persisted only when the decision is `false`. Missing or `true` → recompute next reconcile. This makes the helper self-healing: any previously-cached conservative `true` (e.g. on int03 right now) is automatically reconsidered without manual annotation cleanup.

## Verified against real CRs

- `int03-spotkarp` KarpenterMachinePool: `status.replicas == 0`, confirms the empty-pool skip works
- `int03-cfi9n2dfsa-hgqr6` Machine: `Spec.Bootstrap.DataSecretName == ""`, confirms the bootstrap check was always broken
- `AWSMachinePool.spec.awsLaunchTemplate.ami: {}` (empty object) → `unstructured.NestedString` returns `""` → hard-set-AMI check still works correctly
- Cross-upgrade pollution: `delete(c.Annotations, UpgradeRollsWorkersAnnotation)` is already in both Upgrading-emit paths, so a `false` from a previous upgrade can't carry into a new one