### PR TITLE
fix: Grant RBAC to read AWSMachinePool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Grant the controller's ServiceAccount RBAC to `get`/`list`/`watch` `awsmachinepools.infrastructure.cluster.x-k8s.io`. `willUpgradeRollWorkers` reads `AWSMachinePool.spec.awsLaunchTemplate.imageLookupFormat` (and `ami.id`) to decide whether worker nodes need to roll for the in-flight upgrade; without this permission the `Get` failed with a forbidden error and the helper fell back to the conservative `true`, defeating the no-op detection that v1.3.4 was meant to provide.
+
 ## [1.3.4] - 2026-05-22
 
 ### Fixed

--- a/helm/cluster-api-events/templates/rbac.yaml
+++ b/helm/cluster-api-events/templates/rbac.yaml
@@ -25,6 +25,14 @@ rules:
     - update
     - watch
 - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+  resources:
+    - awsmachinepools
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
     - ""
   resources:
     - secrets

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -103,6 +103,7 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachinepools,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Follow-up to v1.3.4. `willUpgradeRollWorkers` issues a `Get` on `AWSMachinePool` to read the launch template's `imageLookupFormat` (and detect hard-set `ami.id`), but the ServiceAccount's `ClusterRole` doesn't list `awsmachinepools.infrastructure.cluster.x-k8s.io`. Result: the `Get` fails with a forbidden error, the helper falls back to the conservative `true`, and the no-op detection that v1.3.4 was meant to provide doesn't work — int03 stays stuck.

Spotted in the int03 controller log:

```
"willUpgradeRollWorkers: failed to get AWSMachinePool, assuming node roll",
"error":"awsmachinepools.infrastructure.cluster.x-k8s.io \"int03-kv72mv7z6r\" is forbidden:
User \"system:serviceaccount:giantswarm:cluster-api-events\" cannot get resource \"awsmachinepools\"
in API group \"infrastructure.cluster.x-k8s.io\" in the namespace \"org-adidas\""
```

## Changes

- Add `apiGroups: [infrastructure.cluster.x-k8s.io], resources: [awsmachinepools], verbs: [get,list,watch]` to the chart's `ClusterRole`.
- Add the matching `+kubebuilder:rbac` marker on the reconciler for documentation/consistency (the chart RBAC is hand-rolled, not auto-generated from markers, but they should stay in sync).

## Non-AWS providers

Safe on Azure / vSphere MCs:
- `ClusterRole` rules tolerate not-registered resources — applying the chart works regardless of whether the `AWSMachinePool` CRD is installed.
- The controller only reaches the `awsmp.Get(...)` call after checking `infraRef.Kind == "AWSMachinePool"`. On Azure/vSphere that condition is never true (their pools use `AzureMachinePool` / `VSphereMachinePool`), so the Get is never attempted — no errors, no log noise. The no-op detection simply falls back to conservative `true` for non-AWS populated pools, which is the same behavior as before.