### PR TITLE
fix: Evaluate KarpenterMachinePool with kubelet+Flatcar comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Extend `willUpgradeRollWorkers` to evaluate `KarpenterMachinePool` pools the same way as `AWSMachinePool`. Previously a populated Karpenter pool short-circuited the helper to `true`, so clusters mixing AWS and Karpenter pools (e.g. `peu01`) couldn't fire `Upgraded` even when the upgrade was a no-op for every pool's nodes. The helper now parses `spec.ec2NodeClass.amiSelectorTerms[].name` (same Flatcar lookup format as `AWSMachinePool.spec.awsLaunchTemplate.imageLookupFormat`) and applies the same kubelet + OS comparison. Any term with hard-set `id` or `alias`, or any unparseable term, falls back to conservative `true`. RBAC for `karpentermachinepools.infrastructure.cluster.x-k8s.io` is also added. Infrastructure CRD versions are now resolved through the client's REST mapper instead of being hard-coded, so a future bump (e.g. KarpenterMachinePool `v1alpha1` → `v1beta1`) won't silently break the helper.
+
 ## [1.3.5] - 2026-05-22
 
 ### Fixed

--- a/helm/cluster-api-events/templates/rbac.yaml
+++ b/helm/cluster-api-events/templates/rbac.yaml
@@ -28,6 +28,7 @@ rules:
     - infrastructure.cluster.x-k8s.io
   resources:
     - awsmachinepools
+    - karpentermachinepools
   verbs:
     - get
     - list

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -103,7 +103,7 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachinepools,verbs=get;list;watch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachinepools;karpentermachinepools,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -932,60 +932,49 @@ func willUpgradeRollWorkers(ctx context.Context, c client.Client, cluster *capi.
 	for _, mp := range machinePools.Items {
 		infraRef := mp.Spec.Template.Spec.InfrastructureRef
 
-		// Non-AWSMachinePool infra (e.g. KarpenterMachinePool) doesn't have a
-		// CAPA launch template we can introspect uniformly. If the pool has no
-		// nodes, there's nothing to roll for it — skip and check other pools.
-		// If it does have nodes, fall back conservatively.
-		if infraRef.Kind != "AWSMachinePool" {
-			poolReplicas := int32(0)
-			if mp.Status.Replicas != nil {
-				poolReplicas = *mp.Status.Replicas
+		// Empty pools (status.Replicas==0) have no nodes that could need rolling,
+		// regardless of infrastructure kind.
+		poolReplicas := int32(0)
+		if mp.Status.Replicas != nil {
+			poolReplicas = *mp.Status.Replicas
+		}
+		if poolReplicas == 0 {
+			logger.V(1).Info("willUpgradeRollWorkers: pool is empty, skipping",
+				"machinePool", mp.Name, "infraKind", infraRef.Kind)
+			continue
+		}
+
+		var expectedFlatcar, expectedKube string
+		switch infraRef.Kind {
+		case "AWSMachinePool":
+			ef, ek, ok := expectedImageFromAWSMachinePool(ctx, c, mp.Namespace, infraRef.Name)
+			if !ok {
+				logger.Info("willUpgradeRollWorkers: cannot derive expected image from AWSMachinePool, assuming node roll",
+					"machinePool", mp.Name)
+				return true
 			}
-			if poolReplicas == 0 {
-				logger.V(1).Info("willUpgradeRollWorkers: non-AWSMachinePool pool is empty, skipping",
-					"machinePool", mp.Name, "infraKind", infraRef.Kind)
-				continue
+			expectedFlatcar, expectedKube = ef, ek
+		case "KarpenterMachinePool":
+			ef, ek, ok := expectedImageFromKarpenterMachinePool(ctx, c, mp.Namespace, infraRef.Name)
+			if !ok {
+				logger.Info("willUpgradeRollWorkers: cannot derive expected image from KarpenterMachinePool, assuming node roll",
+					"machinePool", mp.Name)
+				return true
 			}
-			logger.Info("willUpgradeRollWorkers: non-AWSMachinePool pool has nodes, assuming node roll",
+			expectedFlatcar, expectedKube = ef, ek
+		default:
+			logger.Info("willUpgradeRollWorkers: unknown infrastructure kind, assuming node roll",
 				"machinePool", mp.Name, "infraKind", infraRef.Kind, "replicas", poolReplicas)
-			return true
-		}
-
-		awsmp := &unstructured.Unstructured{}
-		awsmp.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "infrastructure.cluster.x-k8s.io",
-			Version: "v1beta2",
-			Kind:    "AWSMachinePool",
-		})
-		if err := c.Get(ctx, types.NamespacedName{Namespace: mp.Namespace, Name: infraRef.Name}, awsmp); err != nil {
-			logger.Info("willUpgradeRollWorkers: failed to get AWSMachinePool, assuming node roll",
-				"machinePool", mp.Name, "awsmp", infraRef.Name, "error", err)
-			return true
-		}
-
-		// Hard-set AMI: expected OS isn't derivable without an AWS API call.
-		amiID, _, _ := unstructured.NestedString(awsmp.Object, "spec", "awsLaunchTemplate", "ami", "id")
-		if amiID != "" {
-			logger.Info("willUpgradeRollWorkers: AWSMachinePool uses hard-set ami.id, assuming node roll",
-				"machinePool", mp.Name, "amiID", amiID)
-			return true
-		}
-
-		imageLookupFormat, _, _ := unstructured.NestedString(awsmp.Object, "spec", "awsLaunchTemplate", "imageLookupFormat")
-		expectedFlatcar, expectedKube, parseOK := parseFlatcarImageLookupFormat(imageLookupFormat)
-		if !parseOK {
-			logger.Info("willUpgradeRollWorkers: unparseable imageLookupFormat, assuming node roll",
-				"machinePool", mp.Name, "imageLookupFormat", imageLookupFormat)
 			return true
 		}
 
 		// Note: we intentionally do not compare Machine.Spec.Bootstrap.DataSecretName
 		// here. For MachinePool-owned Machines CAPI doesn't populate that field
 		// per-Machine (the secret reference lives on the MachinePool spec only),
-		// so the comparison would always trigger a false positive.
-		// If a chart bump changes the user-data hash, CAPA refreshes the ASG
-		// instances; the in-flight roll is already caught by the cluster's
-		// RollingOut condition (clusterNotRollingOut guard in the completion check).
+		// so the comparison would always trigger a false positive. If a chart bump
+		// changes the user-data hash, CAPA / Karpenter refreshes instances; the
+		// in-flight roll is already caught by the cluster's RollingOut condition
+		// (clusterNotRollingOut guard in the completion check).
 
 		nodes, err := listNodesForMachinePool(ctx, workloadClient, mp.Name)
 		if err != nil {
@@ -1023,6 +1012,106 @@ func willUpgradeRollWorkers(ctx context.Context, c client.Client, cluster *capi.
 	logger.Info("willUpgradeRollWorkers: all worker nodes already at expected kubelet+Flatcar versions, no node roll required",
 		"cluster", cluster.Name)
 	return false
+}
+
+// getInfraObject fetches an infrastructure CR by group+kind, using the REST
+// mapper to discover the preferred API version. This avoids hard-coding a
+// version that may bump (e.g. KarpenterMachinePool v1alpha1 → v1beta1).
+func getInfraObject(ctx context.Context, c client.Client, namespace, name, group, kind string) (*unstructured.Unstructured, error) {
+	mapping, err := c.RESTMapper().RESTMapping(schema.GroupKind{Group: group, Kind: kind})
+	if err != nil {
+		return nil, fmt.Errorf("resolve REST mapping for %s/%s: %w", group, kind, err)
+	}
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(mapping.GroupVersionKind)
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// expectedImageFromAWSMachinePool fetches the AWSMachinePool and derives the
+// expected Flatcar + kubelet versions from its launch template's
+// imageLookupFormat. Returns ok=false on fetch error, hard-set ami.id (cannot
+// be verified without an AWS API call), or unparseable lookup format.
+func expectedImageFromAWSMachinePool(ctx context.Context, c client.Client, namespace, name string) (flatcar, kube string, ok bool) {
+	logger := log.FromContext(ctx)
+	awsmp, err := getInfraObject(ctx, c, namespace, name, "infrastructure.cluster.x-k8s.io", "AWSMachinePool")
+	if err != nil {
+		logger.Info("expectedImageFromAWSMachinePool: failed to get AWSMachinePool",
+			"awsmp", name, "error", err)
+		return "", "", false
+	}
+	if amiID, _, _ := unstructured.NestedString(awsmp.Object, "spec", "awsLaunchTemplate", "ami", "id"); amiID != "" {
+		logger.Info("expectedImageFromAWSMachinePool: hard-set ami.id, cannot derive expected image",
+			"awsmp", name, "amiID", amiID)
+		return "", "", false
+	}
+	imageLookupFormat, _, _ := unstructured.NestedString(awsmp.Object, "spec", "awsLaunchTemplate", "imageLookupFormat")
+	flatcar, kube, ok = parseFlatcarImageLookupFormat(imageLookupFormat)
+	if !ok {
+		logger.Info("expectedImageFromAWSMachinePool: unparseable imageLookupFormat",
+			"awsmp", name, "imageLookupFormat", imageLookupFormat)
+	}
+	return
+}
+
+// expectedImageFromKarpenterMachinePool fetches the KarpenterMachinePool and
+// derives the expected Flatcar + kubelet versions from the first ami selector
+// term whose `name` field is set to a Giant Swarm flatcar lookup string. Any
+// term with a hard-set `id` or `alias` blocks the derivation since we'd then
+// be unsure which AMI Karpenter actually picks.
+func expectedImageFromKarpenterMachinePool(ctx context.Context, c client.Client, namespace, name string) (flatcar, kube string, ok bool) {
+	logger := log.FromContext(ctx)
+	kmp, err := getInfraObject(ctx, c, namespace, name, "infrastructure.cluster.x-k8s.io", "KarpenterMachinePool")
+	if err != nil {
+		logger.Info("expectedImageFromKarpenterMachinePool: failed to get KarpenterMachinePool",
+			"kmp", name, "error", err)
+		return "", "", false
+	}
+	terms, _, _ := unstructured.NestedSlice(kmp.Object, "spec", "ec2NodeClass", "amiSelectorTerms")
+	if len(terms) == 0 {
+		logger.Info("expectedImageFromKarpenterMachinePool: no amiSelectorTerms", "kmp", name)
+		return "", "", false
+	}
+	for _, t := range terms {
+		term, isMap := t.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		// Any term that pins by id/alias defeats the derivation: Karpenter may
+		// pick that AMI and we can't verify its content without an AWS lookup.
+		if id, _ := term["id"].(string); id != "" {
+			logger.Info("expectedImageFromKarpenterMachinePool: amiSelectorTerm has hard-set id",
+				"kmp", name, "amiID", id)
+			return "", "", false
+		}
+		if alias, _ := term["alias"].(string); alias != "" {
+			logger.Info("expectedImageFromKarpenterMachinePool: amiSelectorTerm has alias",
+				"kmp", name, "alias", alias)
+			return "", "", false
+		}
+	}
+	for _, t := range terms {
+		term, isMap := t.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		nameField, _ := term["name"].(string)
+		if nameField == "" {
+			continue
+		}
+		flatcar, kube, ok = parseFlatcarImageLookupFormat(nameField)
+		if ok {
+			return
+		}
+		logger.Info("expectedImageFromKarpenterMachinePool: unparseable amiSelectorTerm name",
+			"kmp", name, "name", nameField)
+		return "", "", false
+	}
+	logger.Info("expectedImageFromKarpenterMachinePool: no amiSelectorTerm with parseable name",
+		"kmp", name)
+	return "", "", false
 }
 
 // normalizeKubeletVersion prepends "v" if missing so a node's kubeletVersion


### PR DESCRIPTION
Follow-up after v1.3.5. `peu01` on alba stayed stuck because its `KarpenterMachinePool` (`peu01-spotkarp`, 19 nodes) hit the conservative "non-AWS pool has nodes → assume roll" early return, so the helper never got to evaluate the AWS pools that were actually a no-op.

## Changes

- `willUpgradeRollWorkers` now handles `KarpenterMachinePool` alongside `AWSMachinePool`. Karpenter pools carry the same Flatcar lookup string at `spec.ec2NodeClass.amiSelectorTerms[].name`, so the same kubelet + OS comparison applies. Hard-set `id`/`alias` on any selector term, unparseable terms, or fetch failures fall back to conservative `true`.
- Infrastructure CRD versions are now resolved through the client's REST mapper (`c.RESTMapper().RESTMapping(GroupKind{...})`) instead of being hard-coded. Future bumps (e.g. KarpenterMachinePool `v1alpha1` → `v1beta1`, or AWSMachinePool `v1beta2` → `v1beta3`) won't silently break the helper — the lookup automatically follows the preferred version.
- RBAC: adds `karpentermachinepools.infrastructure.cluster.x-k8s.io` (get/list/watch) alongside `awsmachinepools`. Kubebuilder marker updated to match.

## Verified

- `int03-spotkarp` (KarpenterMachinePool) returned earlier confirms the chart renders `amiSelectorTerms` as `[{name: flatcar-stable-…-gs, owner: "…"}]` — same parser handles it.
- `cluster-aws` chart's `_karpenter_machine_pools.tpl` renders exactly one term with `name` (no `id`, no `alias`).
- Safe on non-AWS providers: ClusterRole rules tolerate not-registered resources, and the controller only attempts `Get` when `infraRef.Kind` matches `AWSMachinePool` or `KarpenterMachinePool` (Azure/vSphere pools use different kinds → fall through to the unknown-kind conservative path, which is unchanged from before).

## Expected behavior on peu01 after rollout

- Self-healing: annotation is `"true"` → helper recomputes.
- Karpenter pool now actually checked: if all 19 nodes already run `Flatcar 4459.2.1` + `kubelet v1.33.6`, helper returns `false` for that pool. AWS pools (with the Feb-17 nodes) are also no-op for this release. Annotation persisted as `false` → `Upgraded` fires.
- If any Karpenter node still runs an older Flatcar/kubelet, helper returns `true` and the cluster stays correctly stuck until those nodes roll.